### PR TITLE
run one mocha test

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,17 @@ the [Atomist microgrammar documentation][mg-doc].  You can also take a
 look at the tests in this repository.
 
 [mg-doc]: http://docs.atomist.com/user-guide/rug/microgrammars/ (Atomist Documentation - Microgrammars)
+
+## Development
+
+See the [contribution guidelines](CONTRIBUTING.md).
+
+### Running tests
+
+Run all the tests in mocha:
+
+`npm test`
+
+Run one test file:
+
+`TEST=MyTestFile.ts npm test`

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "autotest": "supervisor -q -n exit -e ts -x npm -- run test",
     "lint": "tslint '**/*.ts' --exclude 'node_modules/**' --exclude 'build/**' -t verbose",
     "fix": "tslint --fix '**/*.ts' --exclude 'node_modules/**' --exclude 'build/**' -t verbose",
-    "test": "mocha --compilers ts:espower-typescript/guess 'test/**/*.ts'"
+    "test": "mocha --compilers ts:espower-typescript/guess \"test/**/${TEST:-*.ts}\""
   }
 }


### PR DESCRIPTION
This is one way to run a single test file, from the command line.

Do it with `TEST=MyTestFile.ts npm test`

I researched getting `npm test File.ts` to work but that's not a thing. There are other ways I could get `npm test -- File.ts` to work, but they'd be harder (creating a separate script, so more indirection) and that's not really any better.

Since it isn't obvious, I added instructions to the README.