### PR TITLE
in Microgrammar.fromString, default undefined ${elements}

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,6 @@
       "integrity": "sha1-x8/BSzph5Ux0xnTB+8kbot8NE5I=",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.66",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.66.tgz",
-      "integrity": "sha512-LpGSiIy5/utq8AT2bSXGnENnS1kCZJ1m84L1yqKst2UehSZe6VWROmiysYg/lLJR6zu2ooeVoQtkUHToA+mEtQ==",
-      "dev": true
-    },
     "@types/mocha": {
       "version": "2.2.41",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.41.tgz",
@@ -362,10 +356,18 @@
       "dev": true
     },
     "espower-typescript": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/espower-typescript/-/espower-typescript-8.0.0.tgz",
-      "integrity": "sha1-G3gCifPf14gBqpGermUi7F/YXEY=",
-      "dev": true
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/espower-typescript/-/espower-typescript-8.0.2.tgz",
+      "integrity": "sha512-9amyGj4QE+JSoIPw0c7TdIPstMm2nYqvvNNVPEW0VJ0iA54uwtX7jTWqpiVOH0iT7c3Cq+HZKqzS52z9ru7JgA==",
+      "dev": true,
+      "dependencies": {
+        "typescript-simple": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/typescript-simple/-/typescript-simple-8.0.3.tgz",
+          "integrity": "sha512-rvmB8QIS5RwypAKT/kN7z2/90zN7iH8Q3EKcWtfDIIArYUut0KKmFyZn1gnWhcjL1jdF/ZDJVNPAVxmE9yPzGw==",
+          "dev": true
+        }
+      }
     },
     "esprima": {
       "version": "2.7.3",
@@ -822,12 +824,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
       "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
-      "dev": true
-    },
-    "typescript-simple": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/typescript-simple/-/typescript-simple-8.0.1.tgz",
-      "integrity": "sha512-52B1+b471W0F1sJytLQpVwD8tFlyDRJ8WrKWoEMfBvA76jY/jPeBU+CW6hXSE6/b/CKEBrjMJXRQcMdA+RIu4Q==",
       "dev": true
     },
     "universal-deep-strict-equal": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/mocha": "^2.2.41",
     "@types/power-assert": "^1.4.29",
     "chai": "^4.0.2",
-    "espower-typescript": "^8.0.0",
+    "espower-typescript": "^8.0.2",
     "mocha": "^3.4.2",
     "power-assert": "^1.4.4",
     "supervisor": "^0.12.0",

--- a/src/Primitives.ts
+++ b/src/Primitives.ts
@@ -28,6 +28,10 @@ export class Literal implements MatchingLogic {
     }
 }
 
+export function isLiteral(ml: MatchingLogic): ml is Literal {
+    return ml && (ml as Literal).literal !== undefined;
+}
+
 /**
  * Support for regex matching. Subclasses can convert the value to
  * whatever type they require.

--- a/src/internal/ExactMatch.ts
+++ b/src/internal/ExactMatch.ts
@@ -1,0 +1,33 @@
+import {Concat} from "../Concat";
+import {MatchingLogic} from "../Matchers";
+import {RestOfInput} from "../matchers/skip/Skip";
+import {DismatchReport, isPatternMatch, MatchFailureReport, PatternMatch} from "../PatternMatch";
+import {InputStream} from "../spi/InputStream";
+import {StringInputStream} from "../spi/StringInputStream";
+import {inputStateFromStream} from "./InputStateFactory";
+
+export function exactMatch<T>(matcher: MatchingLogic, input: string | InputStream): PatternMatch & T | DismatchReport {
+
+    const wrapped = new Concat({
+        desired: matcher,
+        trailingJunk: RestOfInput,
+    });
+    const match = wrapped.matchPrefix(inputStateFromStream(toInputStream(input)), {});
+
+    if (isPatternMatch(match)) {
+        const detyped = match as any;
+        if (detyped.trailingJunk !== "") {
+            return {description:
+                `Not all input was consumed: Left over [${detyped.trailingJunk.$matched}]`};
+        } else {
+            return detyped.desired.$match as (PatternMatch & T);
+        }
+    }
+    return match as MatchFailureReport;
+}
+
+function toInputStream(input: string | InputStream): InputStream {
+    return (typeof input === "string") ?
+        new StringInputStream(input) :
+        input;
+}

--- a/src/internal/MatcherPrinter.ts
+++ b/src/internal/MatcherPrinter.ts
@@ -1,0 +1,37 @@
+import {Concat, isNamedMatcher, MatchStep} from "../Concat";
+import {Matcher, MatchingLogic} from "../Matchers";
+import Match = Chai.Match;
+import {isBreak} from "../matchers/snobol/Break";
+import {isLiteral} from "../Primitives";
+
+/**
+ * Print a matcher structure
+ *
+ * This is implemented only as far as I needed it; let's see whether
+ * we want to use it more before fleshing out the implementation.
+ */
+
+function isMatcher(ml: MatchingLogic | MatchStep): ml is Matcher {
+    return !!((ml as Matcher).name);
+}
+function isConcat(ml: MatchingLogic): ml is Concat {
+    return !!((ml as Concat).matchSteps);
+}
+
+export function print(ml: MatchingLogic): string {
+    if (isConcat(ml)) {
+        const matcherSteps: Matcher[] =
+            ml.matchSteps.filter(s => isMatcher(s)).map(m => m as Matcher);
+        return matcherSteps.map(s => print(s)).join(" ");
+    } else if (isLiteral(ml)) {
+        return ml.literal;
+    } else if (isNamedMatcher(ml)) {
+        return print(ml.ml);
+    } else if (isBreak(ml)) {
+        return("...(" + print(ml.terminateOn) + ")");
+    } else if (isMatcher(ml)) {
+        return `Matcher:${ml.name}`;
+    } else {
+        return "???";
+    }
+}

--- a/src/internal/SpecGrammar.ts
+++ b/src/internal/SpecGrammar.ts
@@ -1,0 +1,30 @@
+import {Concat} from "../Concat";
+import {Term} from "../Matchers";
+import {RestOfInput} from "../matchers/skip/Skip";
+import {Break} from "../matchers/snobol/Break";
+import {Literal, Regex} from "../Primitives";
+import {Rep} from "../Rep";
+
+const elementReference = new Concat({
+    $id: "component",
+    _start: new Literal("${"),
+    elementName: new Regex(/^[a-zA-Z0-9_]+/),
+    _end: new Literal("}"),
+} as Term);
+
+export const specGrammar = new Concat({
+    $id: "spec",
+    these: new Rep(
+        new Concat({
+            $id: "literal, then component",
+            literal: new Break(elementReference),
+            element: elementReference,
+        } as Term)),
+    trailing: RestOfInput, //  matchEverything
+
+});
+
+export interface MicrogrammarSpec {
+    these: Array<{literal: string, element: { elementName: string }}>;
+    trailing: string;
+}

--- a/src/matchers/snobol/Break.ts
+++ b/src/matchers/snobol/Break.ts
@@ -16,7 +16,7 @@ import { isPatternMatch, MatchFailureReport, TerminalPatternMatch } from "../../
  */
 export class Break implements MatchingLogic {
 
-    private terminateOn: MatchingLogic;
+    public terminateOn: MatchingLogic;
     private badMatcher: MatchingLogic;
 
     /**
@@ -66,4 +66,8 @@ export class Break implements MatchingLogic {
         }
         return new TerminalPatternMatch(this.$id, matched, is.offset, matched, context);
     }
+}
+
+export function isBreak(thing: MatchingLogic): thing is Break {
+    return !!(thing as Break).terminateOn;
 }

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -222,9 +222,6 @@ describe("Microgrammar", () => {
         const r0 = result[0] as any;
         expect(r0.$matched).to.equal(content);
         expect(r0.first.namex).to.equal("first");
-
-        // TODO fix this
-        // expect(r0.first.$matched.namex).to.equal("first");
     });
 
     it("2 elements: whitespace insensitive", () => {

--- a/test/fromString/ElementsDefaultToNonGreedyAnyTest.ts
+++ b/test/fromString/ElementsDefaultToNonGreedyAnyTest.ts
@@ -1,0 +1,67 @@
+import assert = require("power-assert");
+import {Microgrammar} from "../../src/Microgrammar";
+import {isPatternMatch} from "../../src/PatternMatch";
+
+describe("Elements default to non-greedy any", () => {
+
+    it("does not require every named element to be defined", () => {
+        const content = "->banana<- ";
+        const mg = Microgrammar.fromString("->${fruit}<-");
+        const result: any = mg.exactMatch(content);
+        assert(isPatternMatch(result));
+        assert(result.fruit === "banana");
+    });
+
+    it("multiple undefined elements are fine if they're separated by a literal", () => {
+        const content = "preamble content ->banana<-juice! and more...";
+        const mg = Microgrammar.fromString<{ fruit: string, drink: string }>("->${fruit}<-${drink}!");
+        const result: any = mg.firstMatch(content);
+        assert(isPatternMatch(result));
+        assert(result.fruit === "banana");
+        assert(result.drink === "juice");
+    });
+
+    it("multiple undefined elements are fine if they're separated by a defined element", () => {
+        const content = "preamble content->banana<-juice! and more...";
+        const mg = Microgrammar.fromString("->${fruit}${arrow}${drink}!",
+            {arrow: "<-"});
+        const result: any = mg.firstMatch(content);
+        assert(result.drink === "juice");
+        assert(result.fruit === "banana");
+    });
+
+    it("doesn't mind whitespace", () => {
+        const content = "->   banana   <- ";
+        const mg = Microgrammar.fromString("-> ${fruit} <-");
+        const result: any = mg.exactMatch(content);
+        assert(isPatternMatch(result));
+        assert(result.fruit.trim() === "banana");
+    });
+
+    it.skip("trims whitespace from the captured text",
+        () => {
+        const content = "->   banana   <- ";
+        const mg = Microgrammar.fromString("-> ${fruit} <-");
+        const result: any = mg.exactMatch(content);
+        assert(isPatternMatch(result));
+        assert(result.fruit === "banana");
+    });
+
+});
+
+function justTheData(match: object): any {
+    if (Array.isArray(match)) {
+        return match.map(m => justTheData(m));
+    }
+
+    if (typeof match !== "object") {
+        return match;
+    }
+    const output = {}; // it is not a const, I mutate it, but tslint won't let me declare otherwise :-(
+    for (const p in match) {
+        if (!(p.indexOf("_") === 0 || p.indexOf("$") === 0)) {
+            output[p] = justTheData(match[p]);
+        }
+    }
+    return output;
+}

--- a/test/fromString/MicrogrammarFromStringTest.ts
+++ b/test/fromString/MicrogrammarFromStringTest.ts
@@ -104,13 +104,7 @@ describe("MicrogrammarFromStringTest", () => {
         expect(result[0].namex).to.equal("first");
     });
 
-    // CONFUSED: the content and the microgrammar match nicely
-    // and yet it isn't supposed to match?
-    // ... so I changed it so they don't match perfectly and this seems correct to me
-    // Like, in a fromString, if you say to be whitespace sensitive, it expects whitespace
-    // to match. But maybe this is a different thing.
-    // It's definitely confusing before...
-    it("2 elements: whitespace sensitive", () => {
+    it("2 elements: whitespace sensitive: match", () => {
         const content = "<first>  notxml";
         const mg = Microgrammar.fromString<{ namex: string[] }>("<${namex}> notxml", {
             namex: /[a-zA-Z0-9]+/,
@@ -119,6 +113,28 @@ describe("MicrogrammarFromStringTest", () => {
         });
         const result = mg.findMatches(content);
         expect(result.length).to.equal(0);
+    });
+
+    it("2 elements: whitespace sensitive: no match", () => {
+        const content = "<first>  notxml";
+        const mg = Microgrammar.fromString<{ namex: string[] }>("<${namex}> notxml", {
+            namex: /[a-zA-Z0-9]+/,
+        }, {
+            consumeWhiteSpaceBetweenTokens: false,
+        });
+        const result = mg.findMatches(content);
+        expect(result.length).to.equal(0);
+    });
+
+    it("2 elements: whitespace sensitive: match with return", () => {
+        const content = "<first>\n\tnotxml";
+        const mg = Microgrammar.fromString<{ namex: string[] }>("<${namex}>\n\tnotxml", {
+            namex: /[a-zA-Z0-9]+/,
+        }, {
+            consumeWhiteSpaceBetweenTokens: false,
+        });
+        const result = mg.findMatches(content);
+        expect(result.length).to.equal(1);
     });
 
     it("stop after match", () => {

--- a/test/fromString/MicrogrammarFromStringTest.ts
+++ b/test/fromString/MicrogrammarFromStringTest.ts
@@ -1,13 +1,13 @@
 import { expect } from "chai";
-import { Microgrammar } from "../src/Microgrammar";
-import { Opt } from "../src/Ops";
-import { PatternMatch } from "../src/PatternMatch";
-import { RepSep } from "../src/Rep";
-import { RealWorldPom } from "./Fixtures";
+import { Microgrammar } from "../../src/Microgrammar";
+import { Opt } from "../../src/Ops";
+import { PatternMatch } from "../../src/PatternMatch";
+import { RepSep } from "../../src/Rep";
+import { RealWorldPom } from "../Fixtures";
 import {
     ALL_PLUGIN_GRAMMAR, ARTIFACT_VERSION_GRAMMAR, LEGAL_VALUE, PLUGIN_GRAMMAR,
     VersionedArtifact,
-} from "./MavenGrammars";
+} from "../MavenGrammars";
 
 describe("MicrogrammarFromStringTest", () => {
 
@@ -104,8 +104,14 @@ describe("MicrogrammarFromStringTest", () => {
         expect(result[0].namex).to.equal("first");
     });
 
+    // CONFUSED: the content and the microgrammar match nicely
+    // and yet it isn't supposed to match?
+    // ... so I changed it so they don't match perfectly and this seems correct to me
+    // Like, in a fromString, if you say to be whitespace sensitive, it expects whitespace
+    // to match. But maybe this is a different thing.
+    // It's definitely confusing before...
     it("2 elements: whitespace sensitive", () => {
-        const content = "<first> notxml";
+        const content = "<first>  notxml";
         const mg = Microgrammar.fromString<{ namex: string[] }>("<${namex}> notxml", {
             namex: /[a-zA-Z0-9]+/,
         }, {

--- a/test/fromString/SpecGrammarTest.ts
+++ b/test/fromString/SpecGrammarTest.ts
@@ -1,0 +1,59 @@
+import assert = require("power-assert");
+import {exactMatch} from "../../src/internal/ExactMatch";
+import {MicrogrammarSpec, specGrammar} from "../../src/internal/SpecGrammar";
+import {isPatternMatch} from "../../src/PatternMatch";
+
+describe("MicrogrammarFromStringTest", () => {
+
+    it("can parse a series of literals and references", () => {
+        const microgrammarSpecString = "->${fruit}<-";
+        const specMatch = exactMatch<MicrogrammarSpec>(specGrammar, microgrammarSpecString);
+        if (isPatternMatch(specMatch)) {
+            assert(specMatch.these.length === 1);
+            assert.deepEqual(justTheData(specMatch),
+            { these: [ {
+                elementName: "fruit", // TODO: this doesn't belong here. Is it a bug in concat?
+                literal: "->", element: {elementName: "fruit"}}]
+            , trailing: "<-"});
+        } else {
+            assert.fail();
+        }
+    });
+
+    it("can parse three references in succession", () => {
+        const specString = "->${fruit}${arrow}${drink}!";
+        const specMatch = exactMatch<MicrogrammarSpec>(specGrammar, specString);
+        if (isPatternMatch(specMatch)) {
+            assert(specMatch.these.length === 3);
+            assert(specMatch.these[0].element.elementName === "fruit");
+            assert(specMatch.these[1].element.elementName === "arrow");
+            assert(specMatch.these[2].element.elementName === "drink");
+            assert(specMatch.trailing === "!");
+        } else {
+            assert.fail();
+        }
+    });
+});
+
+// This will let you print a nested match.
+// (Some of the internal fields are recursive, which can't print;
+//  this strips all internal fields)
+// I want this kind of functionality more globally; I'd rather return
+// to callers of the Microgrammar API matches that have only their data.
+// Or at least give them a way to convert it to only their data.
+function justTheData(match: any): any {
+    if (Array.isArray(match)) {
+        return match.map(m => justTheData(m));
+    }
+
+    if (typeof match !== "object") {
+        return match;
+    }
+    const output = {}; // it is not a const, I mutate it, but tslint won't let me declare otherwise :-(
+    for (const p in match.$context || match) {
+        if (!(p.indexOf("_") === 0 || p.indexOf("$") === 0)) {
+            output[p] = justTheData(match[p]);
+        }
+    }
+    return output;
+}

--- a/test/matchers/java/JavaBlockMicrogrammarTest.ts
+++ b/test/matchers/java/JavaBlockMicrogrammarTest.ts
@@ -16,10 +16,14 @@ describe("JavaBlock microgrammars", () => {
 
 });
 
+/**
+ * Note that these grammars aren't meant to be realistic
+ */
+
 export const JAVA_IDENTIFIER = /^[A-Za-z][a-zA-Z0-9]+/;
 
 const METHOD_GRAMMAR = Microgrammar.fromDefinitions<ChangeControledMethod>({
-    _visibilityModifier: "public", // TODO make optional
+    _visibilityModifier: "public",
     type: JAVA_IDENTIFIER,
     name: JAVA_IDENTIFIER,
     parameterContent: JavaParenthesizedExpression,


### PR DESCRIPTION
in Microgrammar.fromString, default undefined ${elements}
to "everything up to the next matcher."

Now you can write things like `Microgrammar.fromString("def ${methodName}(${params})");`
and it'll just work. You don't have to be explicit about what methodName or params should match, it's just going to grab the stuff up to the close paren and end paren, respectively.

Also included:
- give names to the two kinds of functions we can supply as a MatchStep (veto or alter the context)
- move implementation of exactMatch out to another file, because I want to call it from the fromString implementation and it's a circular dependency otherwise
- the beginning of a print function for microgrammars. I have lots of plans for this, but I implemented only what was useful to me today. As I need more I'll add it
- broke out the specGrammar into its own file and added its own unit tests