### PR TITLE
Simplifies exposed matches

### DIFF
--- a/src/MatchPrefixResult.ts
+++ b/src/MatchPrefixResult.ts
@@ -14,11 +14,4 @@ export interface MatchPrefixResult {
      */
     readonly $matcherId: string;
 
-    /**
-     * Context bound to the match. Context values are normally
-     * bound directly to the match itself, so callers don't
-     * usually need to use this.
-     */
-    readonly $context: {};
-
 }

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -15,11 +15,11 @@ export class MatchFailureReport implements MatchPrefixResult, MatchFailureReport
     public constructor(public readonly $matcherId: string,
                        public readonly $offset: number,
                        $context: {},
-                       private readonly cause?: MatchFailureReport) {
+                       private readonly cause?: string | MatchFailureReport) {
     }
 
     get description(): string {
-        return `Match failed on ${this.$matcherId}`;
+        return `Match failed on ${this.$matcherId}: ${this.cause}`;
     }
 }
 
@@ -62,8 +62,6 @@ export abstract class PatternMatch implements MatchPrefixResult {
         }
     }
 
-    public abstract addOffset(additionalOffset: number): PatternMatch;
-
 }
 
 export function isPatternMatch(mpr: MatchPrefixResult | DismatchReport): mpr is PatternMatch {
@@ -83,15 +81,6 @@ export class TerminalPatternMatch extends PatternMatch {
         super(matcherId, matched, offset, context);
     }
 
-    public addOffset(additionalOffset: number) {
-        return new TerminalPatternMatch(
-            this.$matcherId,
-            this.$matched,
-            this.$offset + additionalOffset,
-            this.$value,
-            {});
-    }
-
 }
 
 /**
@@ -105,11 +94,6 @@ export class UndefinedPatternMatch extends PatternMatch {
                 offset: number) {
 
         super(matcherId, "", offset, {});
-    }
-
-    public addOffset(additionalOffset: number) {
-        return new UndefinedPatternMatch(
-            this.$matcherId, this.$offset + additionalOffset);
     }
 }
 
@@ -162,16 +146,6 @@ export class TreePatternMatch extends PatternMatch {
                 this.$value[$matchers[i].name + MATCH_INFO_SUFFIX] = $subMatches[i];
             }
         }
-    }
-
-    public addOffset(additionalOffset: number) {
-        return new TreePatternMatch(
-            this.$matcherId,
-            this.$matched,
-            this.$offset + additionalOffset,
-            this.$matchers,
-            this.$subMatches.map(m => m.addOffset(additionalOffset)),
-            context);
     }
 
     public submatches() {

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -14,7 +14,7 @@ export class MatchFailureReport implements MatchPrefixResult, MatchFailureReport
 
     public constructor(public readonly $matcherId: string,
                        public readonly $offset: number,
-                       public readonly $context: {},
+                       $context: {},
                        private readonly cause?: MatchFailureReport) {
     }
 
@@ -34,7 +34,7 @@ export abstract class PatternMatch implements MatchPrefixResult {
      * scalar or an array, or a nested structure. May or not be the
      * same as $matched property.
      */
-    public $value: any;
+    public abstract $value: any;
 
     /**
      * Represents a match
@@ -46,7 +46,7 @@ export abstract class PatternMatch implements MatchPrefixResult {
     constructor(public readonly $matcherId: string,
                 public readonly $matched: string,
                 public readonly $offset: number,
-                public readonly $context: {}) {
+                $context: {}) {
         // Copy top level context properties
         // tslint:disable-next-line:forin
         for (const p in $context) {
@@ -89,7 +89,7 @@ export class TerminalPatternMatch extends PatternMatch {
             this.$matched,
             this.$offset + additionalOffset,
             this.$value,
-            this.$context);
+            {});
     }
 
 }

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -155,8 +155,6 @@ export class TreePatternMatch extends PatternMatch {
                 if (!(this as any)[$matchers[i].name]) {
                     (this as any)[$matchers[i].name] = value;
                 }
-                const mn = this.$value[$matchers[i].name] as MatchInfo;
-                mn.$match = $subMatches[i];
                 (this as any)[$matchers[i].name].$match = $subMatches[i];
             } else {
                 // We've got nowhere to put the matching information on a simple value,

--- a/src/Primitives.ts
+++ b/src/Primitives.ts
@@ -14,9 +14,11 @@ export class Literal implements MatchingLogic {
     }
 
     public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
-        return (is.peek(this.literal.length) === this.literal) ?
+        const peek = is.peek(this.literal.length);
+        return (peek === this.literal) ?
             new TerminalPatternMatch(this.$id, this.literal, is.offset, this.literal, context) :
-            new MatchFailureReport(this.$id, is.offset, context);
+            new MatchFailureReport(this.$id, is.offset, context,
+                `Did not match literal [${this.literal}]: saw [${peek}]`);
     }
 
     public canStartWith(char: string): boolean {
@@ -46,8 +48,6 @@ export abstract class AbstractRegex implements MatchingLogic {
         return `Regex: ${this.regex.source}`;
     }
 
-    protected log = false;
-
     /**
      * Match a regular expression
      * @param regex JavaScript regex to match. Don't use an end anchor.
@@ -72,10 +72,6 @@ export abstract class AbstractRegex implements MatchingLogic {
             results = this.regex.exec(remainder);
         } while (results && results[0] === remainder && remainder.length === seen);
 
-        if (this.log) {
-            console.log(`AbstractRegex match for ${this.regex} in [${remainder}...] was [${results}]`);
-        }
-
         if (results && results[0]) {
             // Matched may not be the same as results[0]
             // If there's not an anchor, we may match before
@@ -88,7 +84,8 @@ export abstract class AbstractRegex implements MatchingLogic {
                 this.toValue(actualMatch),
                 context);
         } else {
-            return new MatchFailureReport(this.$id, is.offset, context);
+            return new MatchFailureReport(this.$id, is.offset, context,
+                `Did not match regex /${this.regex.source}/ in [${remainder}]`);
         }
     }
 

--- a/src/Rep.ts
+++ b/src/Rep.ts
@@ -93,7 +93,7 @@ export class Repetition implements MatchingLogic, Configurable {
 
         const values = matches.map(m =>
             (typeof m.$value === "object") ?
-                m.$context :
+                m :
                 m.$value,
         );
 

--- a/src/internal/InputStateFactory.ts
+++ b/src/internal/InputStateFactory.ts
@@ -5,11 +5,26 @@ import { DefaultInputState } from "./DefaultInputState";
 import { InputStateManager } from "./InputStateManager";
 
 import { InputStream } from "../spi/InputStream";
+import { PatternMatch } from "../PatternMatch";
 
-export function inputStateFromString(s: string): InputState {
-    return inputStateFromStream(new StringInputStream(s));
+/**
+ * Return an input state from a string
+ * @param s string
+ * @param offset default 0. If this is specified it enables us to pretend that we are
+ * beginning at a given offset. This allows us to preserve offsets when matching within a match.
+ * @returns {InputState}
+ */
+export function inputStateFromString(s: string, offset: number = 0): InputState {
+    return inputStateFromStream(new StringInputStream(s, offset), offset);
 }
 
-export function inputStateFromStream(str: InputStream): InputState {
-    return new DefaultInputState(new InputStateManager(str), 0);
+/**
+ * Return an input state from a stream
+ * @param str input stream
+ * @param offset default 0. If this is specified it enables us to pretend that we are
+ * beginning at a given offset. This allows us to preserve offsets when matching within a match.
+ * @returns {InputState}
+ */
+export function inputStateFromStream(str: InputStream, offset: number = 0): InputState {
+    return new DefaultInputState(new InputStateManager(str), offset);
 }

--- a/src/internal/InputStateFactory.ts
+++ b/src/internal/InputStateFactory.ts
@@ -4,8 +4,8 @@ import { StringInputStream } from "../spi/StringInputStream";
 import { DefaultInputState } from "./DefaultInputState";
 import { InputStateManager } from "./InputStateManager";
 
-import { InputStream } from "../spi/InputStream";
 import { PatternMatch } from "../PatternMatch";
+import { InputStream } from "../spi/InputStream";
 
 /**
  * Return an input state from a string

--- a/src/internal/MicrogrammarUpdates.ts
+++ b/src/internal/MicrogrammarUpdates.ts
@@ -63,7 +63,7 @@ export class MicrogrammarUpdates {
                             throw new Error(`Cannot set [${key}] on [${target}]: invalidated by parent change`);
                         }
                         cs.change(submatch, newValue);
-                        if (isTreePatternMatch(submatch) && submatch.$subMatches.length > 0) {
+                        if (isTreePatternMatch(submatch) && submatch.submatches() !== {}) {
                             // The caller has set the value of an entire property block.
                             // Invalidate the properties under it
                             for (const prop of Object.getOwnPropertyNames(target)) {

--- a/src/internal/SpecGrammar.ts
+++ b/src/internal/SpecGrammar.ts
@@ -1,16 +1,15 @@
-import {Term} from "../Matchers";
-import {Concat} from "../matchers/Concat";
-import {RestOfInput} from "../matchers/skip/Skip";
-import {Break} from "../matchers/snobol/Break";
-import {Literal, Regex} from "../Primitives";
-import {Rep} from "../Rep";
+import { Concat } from "../matchers/Concat";
+import { RestOfInput } from "../matchers/skip/Skip";
+import { Break } from "../matchers/snobol/Break";
+import { Literal, Regex } from "../Primitives";
+import { Rep } from "../Rep";
 
 const elementReference = new Concat({
     $id: "component",
     _start: new Literal("${"),
     elementName: new Regex(/[a-zA-Z0-9_]+/),
     _end: new Literal("}"),
-} as Term);
+});
 
 export const specGrammar = new Concat({
     $id: "spec",
@@ -19,7 +18,7 @@ export const specGrammar = new Concat({
             $id: "literal, then component",
             literal: new Break(elementReference),
             element: elementReference,
-        } as Term)),
+        })),
     trailing: RestOfInput, //  matchEverything
 
 });

--- a/src/matchers/Concat.ts
+++ b/src/matchers/Concat.ts
@@ -114,7 +114,8 @@ export class Concat implements MatchingLogic {
                         context[step.$id] = report.$value;
                     }
                 } else {
-                    return new MatchFailureReport(this.$id, initialInputState.offset, context);
+                    return new MatchFailureReport(this.$id, initialInputState.offset, context,
+                        `Failed at step '${step.name}' due to ${(report as any).description}`);
                 }
             } else {
                 // It's a function taking the context.

--- a/src/matchers/Concat.ts
+++ b/src/matchers/Concat.ts
@@ -140,7 +140,7 @@ export class Concat implements MatchingLogic {
 
 }
 
-export function isConcat(m: MatchingLogic): boolean {
+export function isConcat(m: MatchingLogic): m is Concat {
     return m && !!((m as Concat).matchSteps || isConcat((m as NamedMatcher).ml));
 }
 

--- a/src/matchers/java/JavaBody.ts
+++ b/src/matchers/java/JavaBody.ts
@@ -1,13 +1,7 @@
 import { InputState } from "../../InputState";
 import { MatchingLogic } from "../../Matchers";
 import { MatchPrefixResult } from "../../MatchPrefixResult";
-import {
-    isPatternMatch,
-    isTreePatternMatch,
-    MatchFailureReport,
-    TerminalPatternMatch,
-    TreePatternMatch,
-} from "../../PatternMatch";
+import { TerminalPatternMatch } from "../../PatternMatch";
 import { Concat } from "../Concat";
 
 import { inputStateFromString } from "../../internal/InputStateFactory";
@@ -80,30 +74,8 @@ class JavaBody implements MatchingLogic {
                 context);
         }
 
-        const innerMatch = this.inner.matchPrefix(inputStateFromString(matched), context);
-        if (isPatternMatch(innerMatch)) {
-            if (isTreePatternMatch(innerMatch)) {
-                // console.log("body has parts");
-                // Tree; take its bits
-                // TODO: test offsets and then adjust them
-                return new TreePatternMatch(
-                    this.$id,
-                    matched,
-                    is.offset,
-                    innerMatch.$matchers,
-                    (innerMatch as TreePatternMatch).$subMatches.map(m => m.addOffset(is.offset)),
-                    context);
-
-            }
-            return new TerminalPatternMatch(
-                this.$id,
-                matched,
-                is.offset,
-                matched,
-                context);
-        } else {
-            return new MatchFailureReport(this.$id, is.offset, innerMatch);
-        }
+        // We supply the offset to preserve it in this match
+        return this.inner.matchPrefix(inputStateFromString(matched, is.offset), context);
     }
 }
 

--- a/src/spi/StringInputStream.ts
+++ b/src/spi/StringInputStream.ts
@@ -1,24 +1,31 @@
-/**
- * Implementation of InputState, backed by a string held in memory.
- */
+
 import { InputStream } from "./InputStream";
 
+/**
+ * Simple implementation of InputStream, backed by a string held in memory.
+ */
 export class StringInputStream implements InputStream {
 
     public offset = 0;
 
-    constructor(public readonly content: string) {
+    /**
+     * Create a new string-backed stream
+     * @param content string
+     * @param initialOffset initial offset. If supplied this pretends to the left
+     * offset of the string. This enables us to match within matches
+     */
+    constructor(public readonly content: string, private readonly initialOffset: number = 0) {
         if (content === undefined) {
             throw new Error("Undefined content");
         }
     }
 
     public exhausted() {
-        return this.offset >= this.content.length;
+        return this.offset - this.initialOffset >= this.content.length;
     }
 
     public read(n: number): string {
-        const s = this.content.substr(this.offset, n);
+        const s = this.content.substr(this.offset - this.initialOffset, n);
         this.offset += s.length;
         // console.log(`read(${n}) returned [${s}], offset now=${this.offset}`);
         return s;

--- a/test/ContextTest.ts
+++ b/test/ContextTest.ts
@@ -7,7 +7,7 @@ import { Integer, LowercaseBoolean } from "../src/Primitives";
 
 describe("ContextTest", () => {
 
-    it("binds calculation to context", () => {
+    it("binds calculation", () => {
         const cc = new Concat({
             a: Integer,
             b: Integer,
@@ -16,7 +16,7 @@ describe("ContextTest", () => {
         const matched: any = cc.matchPrefix(inputStateFromString("24 7"), {});
         assert(matched.a === 24);
         assert(matched.b === 7);
-        assert(matched.$context.sum === 24 + 7);
+        assert(matched.sum === 24 + 7);
     });
 
     it("doesn't veto match based on false calculation", () => {
@@ -29,7 +29,7 @@ describe("ContextTest", () => {
         const matched: any = cc.matchPrefix(inputStateFromString("24 7"), {});
         assert(matched.a === 24);
         assert(matched.b === 7);
-        assert(matched.$context.sum === 24 + 7);
+        assert(matched.sum === 24 + 7);
     });
 
     it("binds calculation to returned value", () => {
@@ -52,7 +52,7 @@ describe("ContextTest", () => {
         });
         const matched: any = cc.matchPrefix(inputStateFromString("24 7"), {});
         assert(matched.a === 24);
-        assert(matched.$context.b === 7);
+        assert(matched.b === 7);
     });
 
     it("rewrites property using transformation", () => {
@@ -62,7 +62,7 @@ describe("ContextTest", () => {
         });
         const matched: any = cc.matchPrefix(inputStateFromString("24 7"), {});
         assert(matched.a === 24);
-        assert(matched.$context.b === 7);
+        assert(matched.b === 7);
     });
 
     it("use function to dictate match", () => {
@@ -89,7 +89,7 @@ describe("ContextTest", () => {
         });
         const matched = cc.matchPrefix(inputStateFromString("gary 7 35"), {});
         assert(isPatternMatch(matched));
-        assert((matched.$context as any).promoted === "gary");
+        assert((matched as any).promoted === "gary");
     });
 
     it("handles multiple bound matches in microgrammar", () => {

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -126,24 +126,6 @@ describe("Microgrammar", () => {
         assert(!isPatternMatch(result));
     });
 
-    it("can JSON stringify", () => {
-        const content = "<foo>";
-        const mg = Microgrammar.fromDefinitions({
-            $id: "elt",
-            lx: "<",
-            name: /[a-zA-Z0-9]+/,
-            rx: ">",
-        } as Term);
-        const result = mg.findMatches(content);
-
-        // console.log("Result is " + JSON.stringify(result));
-        expect(result.length).to.equal(1);
-        const r0 = result[0] as any;
-        const stringified = JSON.stringify(r0);
-        assert(stringified.indexOf("$resultingInputState") === -1);
-        assert(stringified.length < 1500);
-    });
-
     it("XML element", () => {
         const content = "<foo>";
         const mg = Microgrammar.fromDefinitions({

--- a/test/RegexTest.ts
+++ b/test/RegexTest.ts
@@ -52,7 +52,7 @@ describe("Regex", () => {
         const withSkip = new Break(regexp, true);
         const m = withSkip.matchPrefix(is, {});
         assert(isPatternMatch(m));
-        const match = m as PatternMatch;
+        const match = m as any as PatternMatch;
         assert(match.$matched === "**friday");
         assert(match.$offset === 2);
         assert(match.$value === "friday");

--- a/test/RegexTest.ts
+++ b/test/RegexTest.ts
@@ -5,7 +5,7 @@ import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
 import { Regex } from "../src/Primitives";
 
 import * as assert from "power-assert";
-import { Break } from "../build/src/matchers/snobol/Break";
+import { Break } from "../src/matchers/snobol/Break";
 
 describe("Regex", () => {
 

--- a/test/StringificationTest.ts
+++ b/test/StringificationTest.ts
@@ -1,0 +1,53 @@
+import "mocha";
+import { Microgrammar } from "../build/src/Microgrammar";
+
+import * as assert from "power-assert";
+
+describe("stringification", () => {
+
+    it("can JSON stringify microgrammar result", () => {
+        const content = "<foo>";
+        const mg = Microgrammar.fromDefinitions({
+            $id: "elt",
+            lx: "<",
+            name: /[a-zA-Z0-9]+/,
+            rx: ">",
+        });
+        const result = mg.findMatches(content);
+
+        // console.log("Result is " + JSON.stringify(result));
+        assert(result.length === 1);
+        const r0 = result[0] as any;
+        const stringified = JSON.stringify(r0);
+        assert(stringified.indexOf("$resultingInputState") === -1);
+        assert(stringified.length < 1500);
+    });
+
+    it.skip("can JSON stringify gloriously nested microgrammar result", () => {
+        const content = "<foo>";
+        const mg = Microgrammar.fromDefinitions({
+            $id: "elt",
+            lx: "<",
+            name: {
+                name: /[a-zA-Z0-9]+/,
+            },
+            rx: ">",
+        });
+        const result = mg.findMatches(content);
+
+        // console.log("Result is " + JSON.stringify(result));
+        assert(result.length === 1);
+        const r0 = result[0] as any;
+        // for (const prop in r0) {
+        //     console.log(r0[prop]);
+        //     console.log(`Name is ${prop}`);
+        //     console.log(JSON.stringify(r0[prop]));
+        //
+        // }
+
+        const stringified = JSON.stringify(r0);
+        assert(stringified.indexOf("$resultingInputState") === -1);
+        assert(stringified.length < 1500);
+    });
+
+});

--- a/test/StringificationTest.ts
+++ b/test/StringificationTest.ts
@@ -1,7 +1,7 @@
 import "mocha";
-import { Microgrammar } from "../build/src/Microgrammar";
 
 import * as assert from "power-assert";
+import { Microgrammar } from "../src/Microgrammar";
 
 describe("stringification", () => {
 
@@ -26,28 +26,41 @@ describe("stringification", () => {
     it("can JSON stringify gloriously nested microgrammar result", () => {
         const content = "<foo>";
         const mg = Microgrammar.fromDefinitions({
-            $id: "elt",
-            lx: "<",
+            _lx: "<",
             name: {
                 name: /[a-zA-Z0-9]+/,
             },
-            rx: ">",
+            _rx: ">",
         });
         const result = mg.findMatches(content);
 
-        // console.log("Result is " + JSON.stringify(result));
+        console.log("Result is " + JSON.stringify(result));
         assert(result.length === 1);
-        const r0 = result[0] as any;
-        for (const prop in r0) {
-            console.log(r0[prop]);
-            console.log(`Name is ${prop}`);
-            console.log(JSON.stringify(r0[prop]));
 
-        }
-
-        const stringified = JSON.stringify(r0);
+        const stringified = JSON.stringify(result[0]);
         assert(stringified.indexOf("$resultingInputState") === -1);
         assert(stringified.length < 1500);
     });
 
+    it("can extract clean data", () => {
+        const content = "<foo>";
+
+        const mg = Microgrammar.fromDefinitions<Nested>({
+            _lx: "<",
+            person: {
+                name: /[a-zA-Z0-9]+/,
+            },
+            _rx: ">",
+        });
+        const result = mg.findMatches(content);
+        const cleanNested: Nested = result[0].matchedStructure<Nested>();
+        assert(cleanNested.person.name === "foo");
+        assert.deepEqual(cleanNested, { person: { name: "foo" }});
+    });
+
 });
+
+interface Nested {
+
+    person: {name: string};
+}

--- a/test/StringificationTest.ts
+++ b/test/StringificationTest.ts
@@ -23,7 +23,7 @@ describe("stringification", () => {
         assert(stringified.length < 1500);
     });
 
-    it.skip("can JSON stringify gloriously nested microgrammar result", () => {
+    it("can JSON stringify gloriously nested microgrammar result", () => {
         const content = "<foo>";
         const mg = Microgrammar.fromDefinitions({
             $id: "elt",
@@ -38,12 +38,12 @@ describe("stringification", () => {
         // console.log("Result is " + JSON.stringify(result));
         assert(result.length === 1);
         const r0 = result[0] as any;
-        // for (const prop in r0) {
-        //     console.log(r0[prop]);
-        //     console.log(`Name is ${prop}`);
-        //     console.log(JSON.stringify(r0[prop]));
-        //
-        // }
+        for (const prop in r0) {
+            console.log(r0[prop]);
+            console.log(`Name is ${prop}`);
+            console.log(JSON.stringify(r0[prop]));
+
+        }
 
         const stringified = JSON.stringify(r0);
         assert(stringified.indexOf("$resultingInputState") === -1);

--- a/test/fromString/ElementsDefaultToNonGreedyAnyTest.ts
+++ b/test/fromString/ElementsDefaultToNonGreedyAnyTest.ts
@@ -48,20 +48,3 @@ describe("Elements default to non-greedy any", () => {
     });
 
 });
-
-function justTheData(match: object): any {
-    if (Array.isArray(match)) {
-        return match.map(m => justTheData(m));
-    }
-
-    if (typeof match !== "object") {
-        return match;
-    }
-    const output = {}; // it is not a const, I mutate it, but tslint won't let me declare otherwise :-(
-    for (const p in match) {
-        if (!(p.indexOf("_") === 0 || p.indexOf("$") === 0)) {
-            output[p] = justTheData(match[p]);
-        }
-    }
-    return output;
-}

--- a/test/fromString/MicrogrammarFromStringTest.ts
+++ b/test/fromString/MicrogrammarFromStringTest.ts
@@ -9,7 +9,7 @@ import {
     VersionedArtifact,
 } from "../MavenGrammars";
 
-describe("MicrogrammarFromStringTest", () => {
+describe("MicrogrammarFromString", () => {
 
     it("literal", () => {
         const content = "foo ";

--- a/test/fromString/SpecGrammarTest.ts
+++ b/test/fromString/SpecGrammarTest.ts
@@ -1,20 +1,25 @@
 import assert = require("power-assert");
-import {exactMatch} from "../../src/internal/ExactMatch";
-import {MicrogrammarSpec, specGrammar} from "../../src/internal/SpecGrammar";
-import {isPatternMatch} from "../../src/PatternMatch";
+import { exactMatch } from "../../src/internal/ExactMatch";
+import { MicrogrammarSpec, specGrammar } from "../../src/internal/SpecGrammar";
+import { isPatternMatch } from "../../src/PatternMatch";
 
-describe("MicrogrammarFromStringTest", () => {
+describe("SpecGrammar", () => {
 
     it("can parse a series of literals and references", () => {
         const microgrammarSpecString = "->${fruit}<-";
         const specMatch = exactMatch<MicrogrammarSpec>(specGrammar, microgrammarSpecString);
         if (isPatternMatch(specMatch)) {
             assert(specMatch.these.length === 1);
-            assert.deepEqual(justTheData(specMatch),
-            { these: [ {
-                elementName: "fruit", // TODO: this doesn't belong here. Is it a bug in concat?
-                literal: "->", element: {elementName: "fruit"}}]
-            , trailing: "<-"});
+            const json = JSON.stringify(justTheData(specMatch));
+            assert(json ===
+                JSON.stringify({
+                    these: [{
+                        elementName: "fruit", // TODO: this doesn't belong here. Is it a bug in concat?
+                        literal: "->", element: {elementName: "fruit"},
+                    }]
+                    , trailing: "<-",
+                }),
+                json);
         } else {
             assert.fail();
         }

--- a/test/fromString/SpecGrammarTest.ts
+++ b/test/fromString/SpecGrammarTest.ts
@@ -10,7 +10,7 @@ describe("SpecGrammar", () => {
         const specMatch = exactMatch<MicrogrammarSpec>(specGrammar, microgrammarSpecString);
         if (isPatternMatch(specMatch)) {
             assert(specMatch.these.length === 1);
-            const json = JSON.stringify(justTheData(specMatch));
+            const json = JSON.stringify(specMatch.matchedStructure());
             assert(json ===
                 JSON.stringify({
                     these: [{
@@ -39,26 +39,3 @@ describe("SpecGrammar", () => {
         }
     });
 });
-
-// This will let you print a nested match.
-// (Some of the internal fields are recursive, which can't print;
-//  this strips all internal fields)
-// I want this kind of functionality more globally; I'd rather return
-// to callers of the Microgrammar API matches that have only their data.
-// Or at least give them a way to convert it to only their data.
-function justTheData(match: any): any {
-    if (Array.isArray(match)) {
-        return match.map(m => justTheData(m));
-    }
-
-    if (typeof match !== "object") {
-        return match;
-    }
-    const output = {}; // it is not a const, I mutate it, but tslint won't let me declare otherwise :-(
-    for (const p in match.$context || match) {
-        if (!(p.indexOf("_") === 0 || p.indexOf("$") === 0)) {
-            output[p] = justTheData(match[p]);
-        }
-    }
-    return output;
-}

--- a/test/matchers/ConcatTest.ts
+++ b/test/matchers/ConcatTest.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai";
 import { inputStateFromString } from "../../src/internal/InputStateFactory";
-import { Term } from "../../src/Matchers";
 import { Concat } from "../../src/matchers/Concat";
 import { isPatternMatch, PatternMatch } from "../../src/PatternMatch";
 import { Integer } from "../../src/Primitives";
@@ -27,15 +26,12 @@ describe("Concat", () => {
         const mg = new Concat({
             $id: "Foo",
             num: /[1-9][0-9]*/,
-        } as Term);
+        });
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        expect(isPatternMatch(result)).to.equal(true);
-        // expect(result.$matched).to.equal(content);
-        expect(result.$matchers.length).to.equal(1);
-        // expect(result.$matchers[0].$value).to.equal(2);
-        // expect(result.$value).to.equal(2);
-        expect(result.num).to.equal("2");
+        assert(isPatternMatch(result));
+        assert(result.$matched === content);
+        assert(result.num === "2");
     });
 
     it("integer with single digit", () => {


### PR DESCRIPTION
- Removes `$context` from exposed matches
- Removes most public fields from `TreePatternMatch`
- Remove `addOffset` method
- Added `matchedStructure` function on `PatternMatch` to return just the matched data