### PR TITLE
Return context from matchPrefix, instead of supplying one to be modified.

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,60 @@
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.1-JESS"
+editor:
+  name: "ModifyTests"
+  group: "local"
+  artifact: "microgrammar"
+  version: "0.1.0"
+
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.1-JESS"
+editor:
+  name: "ModifyTests"
+  group: "local"
+  artifact: "microgrammar"
+  version: "0.1.0"
+
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.1-JESS"
+editor:
+  name: "ModifyTests"
+  group: "local"
+  artifact: "microgrammar"
+  version: "0.1.0"
+
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.1-JESS"
+editor:
+  name: "ModifyTests"
+  group: "local"
+  artifact: "microgrammar"
+  version: "0.1.0"
+
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.1-JESS"
+editor:
+  name: "ModifyTests"
+  group: "local"
+  artifact: "microgrammar"
+  version: "0.1.0"
+
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.1-JESS"
+editor:
+  name: "ModifyTests"
+  group: "local"
+  artifact: "microgrammar"
+  version: "0.1.0"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/microgrammar/compare/0.3.11...HEAD
 
+### Changed
+
+-   **Breaking** `Concat` moved to `matchers` directory as it should not be
+used directly by end users in most cases.
+
+
 ## [0.4.1] - 2017-07-04
 
 [0.4.1]: https://github.com/atomist/microgrammar/compare/0.4.0...0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+-   **Breaking** `Regex` now adds a start anchor if none is specified.
 -   **Breaking** `Concat` moved to `matchers` directory as it should not be
 used directly by end users in most cases.
 

--- a/src/Concat.ts
+++ b/src/Concat.ts
@@ -43,6 +43,9 @@ export class Concat implements MatchingLogic {
         for (const stepName in definitions) {
             if (["$id", "matchPrefix", "canStartWith", "requiredPrefix"].indexOf(stepName) === -1) {
                 const def = definitions[stepName];
+                if (def === undefined || def === null) {
+                    throw new Error(`Invalid concatenation: Step [${stepName}] is ${def}`);
+                }
                 if (Array.isArray(def) && def.length === 2) {
                     // It's a transformation of a matched return
                     const ml = def[0];

--- a/src/MatchPrefixResult.ts
+++ b/src/MatchPrefixResult.ts
@@ -1,7 +1,7 @@
 import {PatternMatch} from "./PatternMatch";
+
 /**
- * Pattern match. Holds user properties, with user-defined names,
- * and Atomist pattern match properties with a $ prefix.
+ * Result of attempting to match a pattern: MatchFailureReport or SuccessfulMatch.
  */
 export interface MatchPrefixResult {
 
@@ -11,13 +11,13 @@ export interface MatchPrefixResult {
     readonly $offset: number;
 
     /**
-     * Id of the matcher that made the match
+     * Id of the matcher that attempted the match
      */
     readonly $matcherId: string;
 
 }
 
-export class MatchFailureReport implements MatchPrefixResult, MatchFailureReport {
+export class MatchFailureReport implements MatchPrefixResult {
 
     public constructor(public readonly $matcherId: string,
                        public readonly $offset: number,
@@ -31,10 +31,12 @@ export class MatchFailureReport implements MatchPrefixResult, MatchFailureReport
 }
 
 /**
+ * Holds a PatternMatch in the event of success.
  * If this contains a context, then the parent matcher can use that to populate its own;
  * otherwise, it can use the value of the match
  */
 export class SuccessfulMatch implements MatchPrefixResult {
+
     public constructor(public readonly match: PatternMatch,
                        public readonly context?: {} ) {
         if (match === undefined) {

--- a/src/MatchPrefixResult.ts
+++ b/src/MatchPrefixResult.ts
@@ -1,3 +1,4 @@
+import {PatternMatch} from "./PatternMatch";
 /**
  * Pattern match. Holds user properties, with user-defined names,
  * and Atomist pattern match properties with a $ prefix.
@@ -14,4 +15,42 @@ export interface MatchPrefixResult {
      */
     readonly $matcherId: string;
 
+}
+
+export class MatchFailureReport implements MatchPrefixResult, MatchFailureReport {
+
+    public constructor(public readonly $matcherId: string,
+                       public readonly $offset: number,
+                       $context: {},
+                       private readonly cause?: string | MatchFailureReport) {
+    }
+
+    get description(): string {
+        return `Match failed on ${this.$matcherId}: ${this.cause}`;
+    }
+}
+
+export class SuccessfulMatch implements MatchPrefixResult {
+    public constructor(public readonly match: PatternMatch) {
+        if (match === undefined) {
+            throw new Error("You can't be successful with an undefined match");
+        }
+    }
+
+    get $offset() { return this.match.$offset; }
+
+    get $matcherId() { return this.match.$matcherId; }
+
+    get $matched() {
+        return this.match.$matched; } // convenience
+
+    get $value() { return this.match.$value; } // convenience
+}
+
+export function matchPrefixSuccess(match: PatternMatch): MatchPrefixResult {
+    return new SuccessfulMatch(match);
+}
+
+export function isSuccessfulMatch(mpr: MatchPrefixResult): mpr is SuccessfulMatch {
+    return mpr && (mpr as SuccessfulMatch).match !== undefined;
 }

--- a/src/MatchPrefixResult.ts
+++ b/src/MatchPrefixResult.ts
@@ -21,7 +21,7 @@ export class MatchFailureReport implements MatchPrefixResult, MatchFailureReport
 
     public constructor(public readonly $matcherId: string,
                        public readonly $offset: number,
-                       $context: {},
+                       $context?: {},
                        private readonly cause?: string | MatchFailureReport) {
     }
 

--- a/src/MatchPrefixResult.ts
+++ b/src/MatchPrefixResult.ts
@@ -30,8 +30,13 @@ export class MatchFailureReport implements MatchPrefixResult, MatchFailureReport
     }
 }
 
+/**
+ * If this contains a context, then the parent matcher can use that to populate its own;
+ * otherwise, it can use the value of the match
+ */
 export class SuccessfulMatch implements MatchPrefixResult {
-    public constructor(public readonly match: PatternMatch, public readonly context?: {} ) {
+    public constructor(public readonly match: PatternMatch,
+                       public readonly context?: {} ) {
         if (match === undefined) {
             throw new Error("You can't be successful with an undefined match");
         }
@@ -47,7 +52,7 @@ export class SuccessfulMatch implements MatchPrefixResult {
     get $value() { return this.match.$value; } // convenience
 }
 
-export function matchPrefixSuccess(match: PatternMatch, context? : {}): MatchPrefixResult {
+export function matchPrefixSuccess(match: PatternMatch, context?: {}): MatchPrefixResult {
     return new SuccessfulMatch(match, context);
 }
 

--- a/src/MatchPrefixResult.ts
+++ b/src/MatchPrefixResult.ts
@@ -31,7 +31,7 @@ export class MatchFailureReport implements MatchPrefixResult, MatchFailureReport
 }
 
 export class SuccessfulMatch implements MatchPrefixResult {
-    public constructor(public readonly match: PatternMatch) {
+    public constructor(public readonly match: PatternMatch, public readonly context?: {} ) {
         if (match === undefined) {
             throw new Error("You can't be successful with an undefined match");
         }
@@ -47,8 +47,8 @@ export class SuccessfulMatch implements MatchPrefixResult {
     get $value() { return this.match.$value; } // convenience
 }
 
-export function matchPrefixSuccess(match: PatternMatch): MatchPrefixResult {
-    return new SuccessfulMatch(match);
+export function matchPrefixSuccess(match: PatternMatch, context? : {}): MatchPrefixResult {
+    return new SuccessfulMatch(match, context);
 }
 
 export function isSuccessfulMatch(mpr: MatchPrefixResult): mpr is SuccessfulMatch {

--- a/src/Matchers.ts
+++ b/src/Matchers.ts
@@ -42,7 +42,6 @@ export interface MatchingLogic extends Term {
 
 }
 
-
 /**
  * Matching logic associated with a name
  */

--- a/src/Matchers.ts
+++ b/src/Matchers.ts
@@ -42,6 +42,7 @@ export interface MatchingLogic extends Term {
 
 }
 
+
 /**
  * Matching logic associated with a name
  */

--- a/src/Matchers.ts
+++ b/src/Matchers.ts
@@ -32,7 +32,7 @@ export interface MatchingLogic extends Term {
      * @param context context: What's already bound by other matchers,
      * and what this matcher should bind to if it wishes
      */
-    matchPrefix(is: InputState, context: {}): MatchPrefixResult;
+    matchPrefix(is: InputState): MatchPrefixResult;
 
     /**
      * Optimization method. Can a match start with this character?

--- a/src/Microgrammar.ts
+++ b/src/Microgrammar.ts
@@ -175,7 +175,7 @@ export abstract class MatchingMachine {
 
             const previousIs = currentInputState;
             const tryMatch =
-                currentMatcher.matchPrefix(currentInputState, {});
+                currentMatcher.matchPrefix(currentInputState);
 
             // We can't accept empty matches as genuine at this level:
             // For example, if the matcher is just a Rep or Alt
@@ -200,7 +200,7 @@ export abstract class MatchingMachine {
                         currentMatcher = toMatchingLogic(this.observeMatch(m));
                     }
                 } else {
-                    const observerMatch = this.observer.matchPrefix(previousIs, {});
+                    const observerMatch = this.observer.matchPrefix(previousIs);
                     if (isSuccessfulMatch(observerMatch)) {
                         currentMatcher = toMatchingLogic(this.observeMatch(observerMatch.match));
                     }

--- a/src/Microgrammar.ts
+++ b/src/Microgrammar.ts
@@ -1,7 +1,7 @@
-import { Concat, toMatchingLogic } from "./Concat";
 import { Config, DefaultConfig } from "./Config";
 import { InputState } from "./InputState";
 import { MatchingLogic, Term } from "./Matchers";
+import { Concat, toMatchingLogic } from "./matchers/Concat";
 import {DismatchReport, isPatternMatch, PatternMatch} from "./PatternMatch";
 
 import { InputStream } from "./spi/InputStream";

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -19,9 +19,6 @@ export class Opt implements MatchingLogic {
 
     private matcher: MatchingLogic;
 
-    // tslint:disable-next-line:member-ordering
-    public $id = `Opt[${this.matcher}]`;
-
     /**
      * Optional match
      * @param o matching logic
@@ -29,6 +26,10 @@ export class Opt implements MatchingLogic {
      */
     constructor(o: any, private pullUp?: string) {
         this.matcher = toMatchingLogic(o);
+    }
+
+    get $id() {
+        return `Opt[${this.matcher.$id}]`;
     }
 
     public matchPrefix(is: InputState, context: {}): MatchPrefixResult {

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -1,6 +1,6 @@
-import { toMatchingLogic } from "./Concat";
 import { InputState } from "./InputState";
 import { MatchingLogic } from "./Matchers";
+import { toMatchingLogic } from "./matchers/Concat";
 import { MatchPrefixResult } from "./MatchPrefixResult";
 import { isPatternMatch, MATCH_INFO_SUFFIX, MatchFailureReport, UndefinedPatternMatch } from "./PatternMatch";
 

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -2,7 +2,7 @@ import {InputState} from "./InputState";
 import {MatchingLogic} from "./Matchers";
 import {toMatchingLogic} from "./matchers/Concat";
 import {isSuccessfulMatch, MatchFailureReport, MatchPrefixResult, matchPrefixSuccess} from "./MatchPrefixResult";
-import {MATCH_INFO_SUFFIX, UndefinedPatternMatch} from "./PatternMatch";
+import {UndefinedPatternMatch} from "./PatternMatch";
 
 /**
  * Optional match on the given matcher

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -1,8 +1,8 @@
-import { InputState } from "./InputState";
-import { MatchingLogic } from "./Matchers";
-import { toMatchingLogic } from "./matchers/Concat";
+import {InputState} from "./InputState";
+import {MatchingLogic} from "./Matchers";
+import {toMatchingLogic} from "./matchers/Concat";
 import {isSuccessfulMatch, MatchFailureReport, MatchPrefixResult, matchPrefixSuccess} from "./MatchPrefixResult";
-import {  MATCH_INFO_SUFFIX, UndefinedPatternMatch } from "./PatternMatch";
+import {MATCH_INFO_SUFFIX, UndefinedPatternMatch} from "./PatternMatch";
 
 /**
  * Optional match on the given matcher
@@ -11,8 +11,8 @@ import {  MATCH_INFO_SUFFIX, UndefinedPatternMatch } from "./PatternMatch";
  * parent if specified
  * @return {Opt}
  */
-export function optional(o: any, pullUp?: string): MatchingLogic {
-    return new Opt(o, pullUp);
+export function optional(o: any): MatchingLogic {
+    return new Opt(o);
 }
 
 export class Opt implements MatchingLogic {
@@ -24,7 +24,7 @@ export class Opt implements MatchingLogic {
      * @param o matching logic
      * @param pullUp property to pull up if we want one
      */
-    constructor(o: any, private pullUp?: string) {
+    constructor(o: any) {
         this.matcher = toMatchingLogic(o);
     }
 
@@ -40,17 +40,7 @@ export class Opt implements MatchingLogic {
 
         const maybe = this.matcher.matchPrefix(is);
         if (isSuccessfulMatch(maybe)) {
-            if (this.pullUp) {
-                const f = this.pullUp + MATCH_INFO_SUFFIX;
-                const field = maybe.$value[f];
-                if (!field) {
-                    throw new Error(`Cannot pull up field ${f} in ${maybe}`);
-                }
-                maybe.match.$value = field.$value;
-                return matchPrefixSuccess(maybe.match)
-            } else {
-                return maybe;
-            }
+            return maybe;
         }
         return matchPrefixSuccess(new UndefinedPatternMatch(this.$id, is.offset));
     }

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -79,7 +79,7 @@ export class Alt implements MatchingLogic {
         }
 
         for (const matcher of this.matchers) {
-            const m = matcher.matchPrefix(is, context);
+            const m = matcher.matchPrefix(is, {});
             if (isSuccessfulMatch(m)) {
                 return m;
             }

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -32,13 +32,13 @@ export class Opt implements MatchingLogic {
         return `Opt[${this.matcher.$id}]`;
     }
 
-    public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
+    public matchPrefix(is: InputState): MatchPrefixResult {
         if (is.exhausted()) {
             // console.log(`Match from Opt on exhausted stream`);
             return matchPrefixSuccess(new UndefinedPatternMatch(this.$id, is.offset));
         }
 
-        const maybe = this.matcher.matchPrefix(is, context);
+        const maybe = this.matcher.matchPrefix(is);
         if (isSuccessfulMatch(maybe)) {
             if (this.pullUp) {
                 const f = this.pullUp + MATCH_INFO_SUFFIX;
@@ -73,13 +73,13 @@ export class Alt implements MatchingLogic {
         return `Alt(${this.matchers.map(m => m.$id).join(",")})`;
     }
 
-    public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
+    public matchPrefix(is: InputState): MatchPrefixResult {
         if (is.exhausted()) {
             return new MatchFailureReport(this.$id, is.offset, {});
         }
 
         for (const matcher of this.matchers) {
-            const m = matcher.matchPrefix(is, {});
+            const m = matcher.matchPrefix(is);
             if (isSuccessfulMatch(m)) {
                 return m;
             }
@@ -107,7 +107,7 @@ export function when(o: any, matchTest: (PatternMatch) => boolean) {
     }
 
     function conditionalMatch(is: InputState, context: {}): MatchPrefixResult {
-        const result = matcher.matchPrefix(is, context);
+        const result = matcher.matchPrefix(is);
         return (isSuccessfulMatch(result) && matchTest(result.match)) ?
             result :
             new MatchFailureReport(this.$id, is.offset, context);

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -47,8 +47,10 @@ export class Opt implements MatchingLogic {
                     throw new Error(`Cannot pull up field ${f} in ${maybe}`);
                 }
                 maybe.match.$value = field.$value;
+                return matchPrefixSuccess(maybe.match)
+            } else {
+                return maybe;
             }
-            return maybe;
         }
         return matchPrefixSuccess(new UndefinedPatternMatch(this.$id, is.offset));
     }

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -31,14 +31,7 @@ export abstract class PatternMatch {
      */
     constructor(public readonly $matcherId: string,
                 public readonly $matched: string,
-                public readonly $offset: number,
-                $context?: {}) {
-        // Copy top level context properties
-        for (const p in $context) {
-            if (!isSpecialMember(p) && typeof $context[p] !== "function") {
-                this[p] = $context[p];
-            }
-        }
+                public readonly $offset: number) {
     }
 
     /**
@@ -81,7 +74,7 @@ export class UndefinedPatternMatch extends PatternMatch {
     constructor(matcherId: string,
                 offset: number) {
 
-        super(matcherId, "", offset, {});
+        super(matcherId, "", offset);
     }
 }
 
@@ -99,6 +92,9 @@ export const MATCH_INFO_SUFFIX = "$match";
  */
 export class TreePatternMatch extends PatternMatch {
 
+    // JESS: can we put the matcher bits in a $valueMatchers
+    // and then not have a $value
+
     public readonly $value;
 
     constructor($matcherId: string,
@@ -110,8 +106,15 @@ export class TreePatternMatch extends PatternMatch {
         // JESS: I think the context processing should be at this level
         // only TreePatternMatches generate context
 
-        super($matcherId, $matched, $offset, context);
+        super($matcherId, $matched, $offset);
         this.$value = {};
+
+        // Copy top level context properties
+        for (const p in context) {
+            if (!isSpecialMember(p) && typeof context[p] !== "function") {
+                this[p] = context[p];
+            }
+        }
 
         for (let i = 0; i < $subMatches.length; i++) {
             const match = $subMatches[i];

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -79,21 +79,15 @@ export class UndefinedPatternMatch extends PatternMatch {
 }
 
 /**
- * Suffix for properties parallel to string properties that we can't enrich,
- * as they aren't objects
- * @type {string}
- */
-export const MATCH_INFO_SUFFIX = "$match";
-
-/**
  * Represents a complex pattern match. Sets properties to expose structure.
- * In the case of string properties, where we can't add a $match, we expose a parallel
- * <propertyName>$match property with that information.
+ * In the case of string properties, where we can't add provide the whole PatternMatch,
+ * we store that in a parallel object $valueMatches
  */
 export class TreePatternMatch extends PatternMatch {
 
-    // JESS: can we put the matcher bits in a $valueMatchers
-    // and then not have a $value
+    // JESS: can we not have a $value
+
+    public readonly $valueMatches = {};
 
     public readonly $value;
 
@@ -103,9 +97,6 @@ export class TreePatternMatch extends PatternMatch {
                 $matchers: Matcher[],
                 $subMatches: PatternMatch[],
                 context: {}) {
-        // JESS: I think the context processing should be at this level
-        // only TreePatternMatches generate context
-
         super($matcherId, $matched, $offset);
         this.$value = {};
 
@@ -131,7 +122,7 @@ export class TreePatternMatch extends PatternMatch {
                     }
                     // We've got nowhere to put the matching information on a simple value,
                     // so create a parallel property on the parent with an out of band name
-                    this.$value[$matchers[i].name + MATCH_INFO_SUFFIX] = $subMatches[i];
+                    this.$valueMatches[$matchers[i].name] = $subMatches[i];
                 }
             }
         }
@@ -145,7 +136,7 @@ export class TreePatternMatch extends PatternMatch {
                 if (isPatternMatch(value)) {
                     output[key] = value;
                 } else {
-                    output[key] = this.$value[key + MATCH_INFO_SUFFIX];
+                    output[key] = this.$valueMatches[key];
                 }
             }
         }

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -1,4 +1,4 @@
-import { Matcher } from "./Matchers";
+import {Matcher} from "./Matchers";
 
 /**
  * Returned when we failed to match prefix
@@ -32,15 +32,11 @@ export abstract class PatternMatch {
     constructor(public readonly $matcherId: string,
                 public readonly $matched: string,
                 public readonly $offset: number,
-                $context: {}) {
+                $context?: {}) {
         // Copy top level context properties
-        // tslint:disable-next-line:forin
         for (const p in $context) {
-            if (!isSpecialMember(p)) {
-                const val = $context[p];
-                if (typeof val !== "function") {
-                    this[p] = val;
-                }
+            if (!isSpecialMember(p) && typeof $context[p] !== "function") {
+                this[p] = $context[p];
             }
         }
     }
@@ -68,7 +64,7 @@ export class TerminalPatternMatch extends PatternMatch {
                 matched: string,
                 offset: number,
                 public readonly $value: any,
-                context: {}) {
+                context: {} = {}) {
         super(matcherId, matched, offset, context);
     }
 

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -10,7 +10,9 @@ export interface DismatchReport {
 }
 
 /**
- * Represents a successful match.
+ * Represents a successful match. Contains microgrammar information
+ * in fields with names beginning with $ and any user-defined fields.
+ * To ensure this separation works cleanly, not bind user data to fields beginning with $.
  */
 export abstract class PatternMatch {
 
@@ -53,7 +55,7 @@ export function isPatternMatch(mpr: PatternMatch | DismatchReport): mpr is Patte
  */
 export class TerminalPatternMatch extends PatternMatch {
 
-    public terminalness = true;
+    public readonly terminalness = true;
 
     constructor(matcherId: string,
                 matched: string,

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -52,7 +52,7 @@ export abstract class PatternMatch {
 }
 
 export function isPatternMatch(mpr: PatternMatch | DismatchReport): mpr is PatternMatch {
-    return mpr != null && (mpr as PatternMatch).$matched !== undefined;
+    return mpr != null && mpr !== undefined && (mpr as PatternMatch).$matched !== undefined;
 }
 
 /**
@@ -82,15 +82,6 @@ export class UndefinedPatternMatch extends PatternMatch {
 
         super(matcherId, "", offset, {});
     }
-}
-
-/**
- * Properties we add to a matched node
- */
-export interface MatchInfo {
-
-    $match: PatternMatch;
-
 }
 
 /**
@@ -126,7 +117,7 @@ export class TreePatternMatch extends PatternMatch {
                 if (!(this as any)[$matchers[i].name]) {
                     (this as any)[$matchers[i].name] = value;
                 }
-                (this as any)[$matchers[i].name].$match = $subMatches[i];
+             //   (this as any)[$matchers[i].name].$match = $subMatches[i];
             } else {
                 // We've got nowhere to put the matching information on a simple value,
                 // so create a parallel property on the parent with an out of band name
@@ -140,8 +131,8 @@ export class TreePatternMatch extends PatternMatch {
         for (const key of Object.getOwnPropertyNames(this)) {
             if (key.charAt(0) !== "$") {
                 const value = this[key];
-                if (typeof value === "object") {
-                    output[key] = value.$match;
+                if (isPatternMatch(value)) {
+                    output[key] = value;
                 } else {
                     output[key] = this.$value[key + MATCH_INFO_SUFFIX];
                 }

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -1,5 +1,4 @@
 import { Matcher } from "./Matchers";
-import { MatchPrefixResult } from "./MatchPrefixResult";
 
 /**
  * Returned when we failed to match prefix
@@ -10,23 +9,10 @@ export interface DismatchReport {
     description: string;
 }
 
-export class MatchFailureReport implements MatchPrefixResult, MatchFailureReport {
-
-    public constructor(public readonly $matcherId: string,
-                       public readonly $offset: number,
-                       $context: {},
-                       private readonly cause?: string | MatchFailureReport) {
-    }
-
-    get description(): string {
-        return `Match failed on ${this.$matcherId}: ${this.cause}`;
-    }
-}
-
 /**
  * Represents a successful match.
  */
-export abstract class PatternMatch implements MatchPrefixResult {
+export abstract class PatternMatch {
 
     /**
      * Value extracted from matcher.
@@ -69,7 +55,7 @@ export abstract class PatternMatch implements MatchPrefixResult {
 
 }
 
-export function isPatternMatch(mpr: MatchPrefixResult | DismatchReport): mpr is PatternMatch {
+export function isPatternMatch(mpr: PatternMatch | DismatchReport): mpr is PatternMatch {
     return mpr != null && (mpr as PatternMatch).$matched !== undefined;
 }
 
@@ -170,8 +156,8 @@ export class TreePatternMatch extends PatternMatch {
 
 }
 
-export function isTreePatternMatch(mpr: MatchPrefixResult): mpr is TreePatternMatch {
-    return mpr != null && (mpr as TreePatternMatch).submatches !== undefined;
+export function isTreePatternMatch(om: PatternMatch): om is TreePatternMatch {
+    return om != null && (om as TreePatternMatch).submatches !== undefined;
 }
 
 /**

--- a/src/Primitives.ts
+++ b/src/Primitives.ts
@@ -1,7 +1,7 @@
 import { InputState } from "./InputState";
 import { MatchingLogic } from "./Matchers";
-import { MatchPrefixResult } from "./MatchPrefixResult";
-import { MatchFailureReport, TerminalPatternMatch } from "./PatternMatch";
+import {MatchFailureReport, MatchPrefixResult, matchPrefixSuccess} from "./MatchPrefixResult";
+import {  TerminalPatternMatch } from "./PatternMatch";
 
 /**
  * Match a literal string
@@ -16,7 +16,7 @@ export class Literal implements MatchingLogic {
     public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
         const peek = is.peek(this.literal.length);
         return (peek === this.literal) ?
-            new TerminalPatternMatch(this.$id, this.literal, is.offset, this.literal, context) :
+            matchPrefixSuccess(new TerminalPatternMatch(this.$id, this.literal, is.offset, this.literal, context) ) :
             new MatchFailureReport(this.$id, is.offset, context,
                 `Did not match literal [${this.literal}]: saw [${peek}]`);
     }
@@ -77,12 +77,12 @@ export abstract class AbstractRegex implements MatchingLogic {
             // If there's not an anchor, we may match before
             const actualMatch = results[0];
             const matched = remainder.substring(0, remainder.indexOf(actualMatch)) + actualMatch;
-            return new TerminalPatternMatch(
+            return matchPrefixSuccess(new TerminalPatternMatch(
                 this.$id,
                 matched,
                 is.offset,
                 this.toValue(actualMatch),
-                context);
+                context));
         } else {
             return new MatchFailureReport(this.$id, is.offset, context,
                 `Did not match regex /${this.regex.source}/ in [${remainder}]`);

--- a/src/Primitives.ts
+++ b/src/Primitives.ts
@@ -91,8 +91,7 @@ export abstract class AbstractRegex implements MatchingLogic {
                 this.$id,
                 matched,
                 is.offset,
-                this.toValue(matched),
-                context));
+                this.toValue(matched)));
         } else {
             return new MatchFailureReport(this.$id, is.offset, context,
                 `Did not match regex /${this.regex.source}/ in [${lookAt}]`);

--- a/src/Primitives.ts
+++ b/src/Primitives.ts
@@ -13,11 +13,11 @@ export class Literal implements MatchingLogic {
     constructor(public literal: string) {
     }
 
-    public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
+    public matchPrefix(is: InputState): MatchPrefixResult {
         const peek = is.peek(this.literal.length);
         return (peek === this.literal) ?
-            matchPrefixSuccess(new TerminalPatternMatch(this.$id, this.literal, is.offset, this.literal, context) ) :
-            new MatchFailureReport(this.$id, is.offset, context,
+            matchPrefixSuccess(new TerminalPatternMatch(this.$id, this.literal, is.offset, this.literal) ) :
+            new MatchFailureReport(this.$id, is.offset, {},
                 `Did not match literal [${this.literal}]: saw [${peek}]`);
     }
 
@@ -59,7 +59,7 @@ export abstract class AbstractRegex implements MatchingLogic {
         this.regex = regex.source.charAt(0) !== "^" ? new RegExp("^" + regex.source) : regex;
     }
 
-    public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
+    public matchPrefix(is: InputState): MatchPrefixResult {
         let results: RegExpExecArray;
         let lookAt: string;
         let charactersToSee = 0;
@@ -93,7 +93,7 @@ export abstract class AbstractRegex implements MatchingLogic {
                 is.offset,
                 this.toValue(matched)));
         } else {
-            return new MatchFailureReport(this.$id, is.offset, context,
+            return new MatchFailureReport(this.$id, is.offset, {},
                 `Did not match regex /${this.regex.source}/ in [${lookAt}]`);
         }
     }

--- a/src/Primitives.ts
+++ b/src/Primitives.ts
@@ -72,10 +72,9 @@ export abstract class AbstractRegex implements MatchingLogic {
             return results[0] === lookAt;
         }
 
-        function thereIsMoreToRead() : boolean {
+        function thereIsMoreToRead(): boolean {
             return lookAt.length === charactersToSee;
         }
-
 
         // Keep asking for more input if we have matched all of the input in
         // our lookahead buffer

--- a/src/Primitives.ts
+++ b/src/Primitives.ts
@@ -40,17 +40,23 @@ const LOOK_AHEAD_SIZE = 100;
  */
 export abstract class AbstractRegex implements MatchingLogic {
 
-    public $id = `Regex: ${this.regex.source}`;
+    public readonly regex: RegExp;
+
+    get $id() {
+        return `Regex: ${this.regex.source}`;
+    }
 
     protected log = false;
 
     /**
      * Match a regular expression
-     * @param regex JavaScript regex to match
+     * @param regex JavaScript regex to match. Don't use an end anchor.
+     * Start anchor will be added if not already there
      * @param lookahead number of characters to pull from the input to try to match.
      * We'll keep grabbing more if a match is found for the whole string
      */
-    constructor(public regex: RegExp, private lookahead: number = LOOK_AHEAD_SIZE) {
+    constructor(regex: RegExp, private lookahead: number = LOOK_AHEAD_SIZE) {
+        this.regex = regex.source.charAt(0) !== "^" ? new RegExp("^" + regex.source) : regex;
     }
 
     public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
@@ -102,11 +108,9 @@ export class Regex extends AbstractRegex {
     /**
      * Create wrapping a native JavaScript regular expression
      * @param regex Regular expression to wrap.
-     * Do not use an end anchor.
-     * If you use a start anchor, the match must begin at the beginning.
-     * If you do not use a start anchor, content can be skipped.
+     * Do not use an end anchor. If a start anchor isn't provided it will be added
      */
-    constructor(public regex: RegExp) {
+    constructor(regex: RegExp) {
         super(regex);
     }
 
@@ -118,7 +122,7 @@ export class Regex extends AbstractRegex {
 export class MatchInteger extends AbstractRegex {
 
     constructor() {
-        super(/^[1-9][0-9]*/);
+        super(/[1-9][0-9]*/);
     }
 
     public canStartWith(c: string): boolean {
@@ -139,7 +143,7 @@ export const Integer = new MatchInteger();
 export class MatchFloat extends AbstractRegex {
 
     constructor() {
-        super(/^[+-]?\d*[\.]?\d+/);
+        super(/[+-]?\d*[\.]?\d+/);
     }
 
     protected toValue(s: string) {

--- a/src/Rep.ts
+++ b/src/Rep.ts
@@ -1,7 +1,7 @@
-import { isConcat, toMatchingLogic } from "./Concat";
 import { Config, Configurable, DefaultConfig } from "./Config";
 import { InputState } from "./InputState";
 import { MatchingLogic} from "./Matchers";
+import { isConcat, toMatchingLogic } from "./matchers/Concat";
 import { MatchPrefixResult } from "./MatchPrefixResult";
 import { isPatternMatch, MatchFailureReport, PatternMatch, TerminalPatternMatch } from "./PatternMatch";
 

--- a/src/Rep.ts
+++ b/src/Rep.ts
@@ -54,7 +54,7 @@ export class Repetition implements MatchingLogic, Configurable {
             this.matcher.requiredPrefix;
     }
 
-    public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
+    public matchPrefix(is: InputState): MatchPrefixResult {
         let currentInputState = is;
         const matches: PatternMatch[] = [];
         let matched = "";
@@ -63,9 +63,7 @@ export class Repetition implements MatchingLogic, Configurable {
             currentInputState = eat.state;
             matched += eat.skipped;
 
-            const contextToUse = isConcat(this.matcher) ? {} : context;
-
-            const result = this.matcher.matchPrefix(currentInputState, contextToUse);
+            const result = this.matcher.matchPrefix(currentInputState);
             if (!isSuccessfulMatch(result)) {
                 break;
             } else {
@@ -83,7 +81,7 @@ export class Repetition implements MatchingLogic, Configurable {
                 const eaten = readyToMatch(currentInputState, this.config);
                 currentInputState = eaten.state;
                 matched += eaten.skipped;
-                const sepMatchResult = this.sepMatcher.matchPrefix(currentInputState, context);
+                const sepMatchResult = this.sepMatcher.matchPrefix(currentInputState);
                 if (isSuccessfulMatch(sepMatchResult)) {
                     const sepMatch = sepMatchResult.match;
                     currentInputState = currentInputState.consume(sepMatch.$matched);
@@ -104,9 +102,8 @@ export class Repetition implements MatchingLogic, Configurable {
             matchPrefixSuccess(new TerminalPatternMatch(this.$id,
                 matched,
                 is.offset,
-                values,
-                context)) :
-            new MatchFailureReport(this.$id, is.offset, context);
+                values)) :
+            new MatchFailureReport(this.$id, is.offset, {});
     }
 }
 

--- a/src/Rep.ts
+++ b/src/Rep.ts
@@ -68,6 +68,10 @@ export class Repetition implements MatchingLogic, Configurable {
             if (!isPatternMatch(match)) {
                 break;
             } else {
+                if (match.$matched === "") {
+                    throw new Error(`Matcher with id ${this.matcher.$id} within rep matched the empty string.\n` +
+                     `I do not think this grammar means what you think it means`);
+                }
                 currentInputState = currentInputState.consume(match.$matched);
                 matches.push(match);
                 matched += match.$matched;

--- a/src/internal/ExactMatch.ts
+++ b/src/internal/ExactMatch.ts
@@ -1,7 +1,8 @@
 import {MatchingLogic} from "../Matchers";
 import {Concat} from "../matchers/Concat";
 import {RestOfInput} from "../matchers/skip/Skip";
-import {DismatchReport, isPatternMatch, MatchFailureReport, PatternMatch} from "../PatternMatch";
+import {isSuccessfulMatch, MatchFailureReport} from "../MatchPrefixResult";
+import {DismatchReport, PatternMatch} from "../PatternMatch";
 import {InputStream} from "../spi/InputStream";
 import {StringInputStream} from "../spi/StringInputStream";
 import {inputStateFromStream} from "./InputStateFactory";
@@ -14,8 +15,8 @@ export function exactMatch<T>(matcher: MatchingLogic, input: string | InputStrea
     });
     const match = wrapped.matchPrefix(inputStateFromStream(toInputStream(input)), {});
 
-    if (isPatternMatch(match)) {
-        const detyped = match as any;
+    if (isSuccessfulMatch(match)) {
+        const detyped = match.match as any;
         if (detyped.trailingJunk !== "") {
             return {description:
                 `Not all input was consumed: Left over [${detyped.trailingJunk.$matched}]`};

--- a/src/internal/ExactMatch.ts
+++ b/src/internal/ExactMatch.ts
@@ -13,7 +13,7 @@ export function exactMatch<T>(matcher: MatchingLogic, input: string | InputStrea
         desired: matcher,
         trailingJunk: RestOfInput,
     });
-    const result = wrapped.matchPrefix(inputStateFromStream(toInputStream(input)), {});
+    const result = wrapped.matchPrefix(inputStateFromStream(toInputStream(input)));
 
     if (isSuccessfulMatch(result)) {
         const detyped = result.match as any;

--- a/src/internal/ExactMatch.ts
+++ b/src/internal/ExactMatch.ts
@@ -1,5 +1,5 @@
-import {Concat} from "../Concat";
 import {MatchingLogic} from "../Matchers";
+import {Concat} from "../matchers/Concat";
 import {RestOfInput} from "../matchers/skip/Skip";
 import {DismatchReport, isPatternMatch, MatchFailureReport, PatternMatch} from "../PatternMatch";
 import {InputStream} from "../spi/InputStream";

--- a/src/internal/ExactMatch.ts
+++ b/src/internal/ExactMatch.ts
@@ -13,18 +13,18 @@ export function exactMatch<T>(matcher: MatchingLogic, input: string | InputStrea
         desired: matcher,
         trailingJunk: RestOfInput,
     });
-    const match = wrapped.matchPrefix(inputStateFromStream(toInputStream(input)), {});
+    const result = wrapped.matchPrefix(inputStateFromStream(toInputStream(input)), {});
 
-    if (isSuccessfulMatch(match)) {
-        const detyped = match.match as any;
+    if (isSuccessfulMatch(result)) {
+        const detyped = result.match as any;
         if (detyped.trailingJunk !== "") {
             return {description:
                 `Not all input was consumed: Left over [${detyped.trailingJunk.$matched}]`};
         } else {
-            return detyped.desired.$match as (PatternMatch & T);
+            return detyped.desired as (PatternMatch & T);
         }
     }
-    return match as MatchFailureReport;
+    return result as MatchFailureReport;
 }
 
 function toInputStream(input: string | InputStream): InputStream {

--- a/src/internal/MatcherPrinter.ts
+++ b/src/internal/MatcherPrinter.ts
@@ -1,5 +1,5 @@
-import {Concat, isNamedMatcher, MatchStep} from "../Concat";
 import {Matcher, MatchingLogic} from "../Matchers";
+import {Concat, isNamedMatcher, MatchStep} from "../matchers/Concat";
 import Match = Chai.Match;
 import {isBreak} from "../matchers/snobol/Break";
 import {isLiteral} from "../Primitives";

--- a/src/internal/MicrogrammarSpecParser.ts
+++ b/src/internal/MicrogrammarSpecParser.ts
@@ -1,11 +1,10 @@
 import {Config, DefaultConfig} from "../Config";
 import {MatchingLogic} from "../Matchers";
 import {Concat, toMatchingLogic} from "../matchers/Concat";
-import {isPatternMatch} from "../PatternMatch";
 import {Literal} from "../Primitives";
-import * as MatcherPrinter from "./MatcherPrinter";
 
 import {Break} from "../matchers/snobol/Break";
+import {isPatternMatch} from "../PatternMatch";
 import {exactMatch} from "./ExactMatch";
 import {MicrogrammarSpec, specGrammar} from "./SpecGrammar";
 

--- a/src/internal/MicrogrammarSpecParser.ts
+++ b/src/internal/MicrogrammarSpecParser.ts
@@ -1,6 +1,6 @@
-import {Concat, toMatchingLogic} from "../Concat";
 import {Config, DefaultConfig} from "../Config";
 import {MatchingLogic} from "../Matchers";
+import {Concat, toMatchingLogic} from "../matchers/Concat";
 import {isPatternMatch} from "../PatternMatch";
 import {Literal} from "../Primitives";
 import * as MatcherPrinter from "./MatcherPrinter";

--- a/src/internal/MicrogrammarUpdates.ts
+++ b/src/internal/MicrogrammarUpdates.ts
@@ -39,15 +39,15 @@ export class MicrogrammarUpdates {
             const submatches = match.submatches();
             // tslint:disable-next-line:forin
             for (const key in submatches) {
-                console.log(`Making property for ${key}`)
+                console.log(`Making property for ${key}`);
                 const submatch = submatches[key] as PatternMatch;
                 let initialValue;
                 if (isTreePatternMatch(submatch) && submatch.submatches() === {}) {
-                    console.log(" It's a tree with no submatches")
+                    console.log(" It's a tree with no submatches");
                     initialValue = submatch.$matched; // or $value ? they should both be the string value.
                     // this could also be derived from content + offset, which reduces memory consumption
                 } else {
-                    console.log(" adding nested properties" + JSON.stringify(submatch))
+                    console.log(" adding nested properties" + JSON.stringify(submatch));
                     initialValue = {};
                     this.addMatchesAsProperties(initialValue, cs, submatch);
                 }
@@ -80,7 +80,7 @@ export class MicrogrammarUpdates {
                 });
             }
         } else {
-            console.log(`Not a tree pattern match: ${JSON.stringify(match)}`)
+            console.log(`Not a tree pattern match: ${JSON.stringify(match)}`);
         }
     }
 }

--- a/src/internal/MicrogrammarUpdates.ts
+++ b/src/internal/MicrogrammarUpdates.ts
@@ -23,6 +23,7 @@ export class MicrogrammarUpdates {
                 this.$changeSet.change(match, newValue);
             },
         };
+        console.log("The top level match target is " + JSON.stringify(match));
         this.addMatchesAsProperties(updating, updating.$changeSet, match);
         return updating as (T & MatchUpdater);
     }
@@ -38,12 +39,15 @@ export class MicrogrammarUpdates {
             const submatches = match.submatches();
             // tslint:disable-next-line:forin
             for (const key in submatches) {
+                console.log(`Making property for ${key}`)
                 const submatch = submatches[key] as PatternMatch;
                 let initialValue;
                 if (isTreePatternMatch(submatch) && submatch.submatches() === {}) {
+                    console.log(" It's a tree with no submatches")
                     initialValue = submatch.$matched; // or $value ? they should both be the string value.
                     // this could also be derived from content + offset, which reduces memory consumption
                 } else {
+                    console.log(" adding nested properties" + JSON.stringify(submatch))
                     initialValue = {};
                     this.addMatchesAsProperties(initialValue, cs, submatch);
                 }
@@ -75,6 +79,8 @@ export class MicrogrammarUpdates {
                     configurable: true,
                 });
             }
+        } else {
+            console.log(`Not a tree pattern match: ${JSON.stringify(match)}`)
         }
     }
 }

--- a/src/internal/SpecGrammar.ts
+++ b/src/internal/SpecGrammar.ts
@@ -8,7 +8,7 @@ import {Rep} from "../Rep";
 const elementReference = new Concat({
     $id: "component",
     _start: new Literal("${"),
-    elementName: new Regex(/^[a-zA-Z0-9_]+/),
+    elementName: new Regex(/[a-zA-Z0-9_]+/),
     _end: new Literal("}"),
 } as Term);
 

--- a/src/internal/SpecGrammar.ts
+++ b/src/internal/SpecGrammar.ts
@@ -1,5 +1,5 @@
-import {Concat} from "../Concat";
 import {Term} from "../Matchers";
+import {Concat} from "../matchers/Concat";
 import {RestOfInput} from "../matchers/skip/Skip";
 import {Break} from "../matchers/snobol/Break";
 import {Literal, Regex} from "../Primitives";

--- a/src/matchers/Concat.ts
+++ b/src/matchers/Concat.ts
@@ -1,12 +1,12 @@
-import { Config, DefaultConfig } from "./Config";
-import { InputState } from "./InputState";
-import { Matcher, MatchingLogic, Term } from "./Matchers";
-import { MatchPrefixResult } from "./MatchPrefixResult";
-import { Microgrammar } from "./Microgrammar";
-import { isPatternMatch, isSpecialMember, MatchFailureReport, PatternMatch, TreePatternMatch } from "./PatternMatch";
-import { Literal, Regex } from "./Primitives";
+import { Config, DefaultConfig } from "../Config";
+import { InputState } from "../InputState";
+import { Matcher, MatchingLogic, Term } from "../Matchers";
+import { MatchPrefixResult } from "../MatchPrefixResult";
+import { Microgrammar } from "../Microgrammar";
+import { isPatternMatch, isSpecialMember, MatchFailureReport, PatternMatch, TreePatternMatch } from "../PatternMatch";
+import { Literal, Regex } from "../Primitives";
 
-import { readyToMatch } from "./internal/Whitespace";
+import { readyToMatch } from "../internal/Whitespace";
 
 /**
  * Represents something that can be passed into a microgrammar
@@ -29,7 +29,10 @@ export type MatchStep = Matcher | MatchVeto | ContextChange;
 /**
  * Represents a concatenation of multiple matchers. This is the normal
  * way we compose matches, although this class needn't be used explicitly,
- * as Microgrammars use it.
+ * as Microgrammars use it, via fromDefinitions or by composition involving
+ * an object literal which will be converted to a Concat.
+ * Users should only create Concats directly in the unusual case where they need
+ * to control whitespace handling in a unique way for that particular Concat.
  */
 export class Concat implements MatchingLogic {
 

--- a/src/matchers/Concat.ts
+++ b/src/matchers/Concat.ts
@@ -27,7 +27,7 @@ function isMatchVeto(thing: MatchStep): thing is MatchVeto {
  */
 export type MatchStep = Matcher | MatchVeto | ContextChange;
 
-const methodsOnEveryMatchingLogic = ["$id", "matchPrefix", "canStartWith", "requiredPrefix"]
+const methodsOnEveryMatchingLogic = ["$id", "matchPrefix", "canStartWith", "requiredPrefix"];
 
 /**
  * Represents a concatenation of multiple matchers. This is the normal
@@ -44,7 +44,6 @@ export class Concat implements MatchingLogic {
     // Used to check first matcher. We want to do that to check
     // for required prefix etc.
     private readonly firstMatcher: Matcher;
-
 
     constructor(public definitions: any, public config: Config = DefaultConfig) {
         for (const stepName in definitions) {

--- a/src/matchers/Concat.ts
+++ b/src/matchers/Concat.ts
@@ -95,7 +95,6 @@ export class Concat implements MatchingLogic {
         let matched = "";
         for (const step of this.matchSteps) {
             if (isMatcher(step)) {
-                // JESS: pass the matcher in for requiredPrefix optimization?
                 const eat = readyToMatch(currentInputState, this.config);
                 currentInputState = eat.state;
                 matched += eat.skipped;

--- a/src/matchers/Concat.ts
+++ b/src/matchers/Concat.ts
@@ -88,7 +88,7 @@ export class Concat implements MatchingLogic {
         return this.firstMatcher.requiredPrefix;
     }
 
-    public matchPrefix(initialInputState: InputState, whyAcceptOne: {}): MatchPrefixResult {
+    public matchPrefix(initialInputState: InputState): MatchPrefixResult {
         const context = {};
         const matches: PatternMatch[] = [];
         let currentInputState = initialInputState;
@@ -100,7 +100,7 @@ export class Concat implements MatchingLogic {
                 currentInputState = eat.state;
                 matched += eat.skipped;
 
-                const reportResult = step.matchPrefix(currentInputState, context);
+                const reportResult = step.matchPrefix(currentInputState);
                 if (isSuccessfulMatch(reportResult)) {
                     const report = reportResult.match;
                     matches.push(report);
@@ -108,11 +108,9 @@ export class Concat implements MatchingLogic {
                     matched += report.$matched;
                     if (reportResult.context) {
                         // Bind the nested context if necessary
-                       // console.log(`Binding ${step.$id} to object [${JSON.stringify(report)}]`)
-                        context[step.$id] = report;
+                        context[step.$id] = reportResult.context;
                     } else {
-                       // console.log(`Binding ${step.$id} to  value [${JSON.stringify(report.$value)}]`)
-
+                        // otherwise, give the context the matcher's value.
                         context[step.$id] = report.$value;
                     }
                 } else {
@@ -186,8 +184,8 @@ export class NamedMatcher implements Matcher {
     constructor(public name: string, public ml: MatchingLogic) {
     }
 
-    public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
-        return this.ml.matchPrefix(is, context) as PatternMatch;
+    public matchPrefix(is: InputState): MatchPrefixResult {
+        return this.ml.matchPrefix(is) as PatternMatch;
     }
 
     public canStartWith(char: string): boolean {

--- a/src/matchers/java/JavaBody.ts
+++ b/src/matchers/java/JavaBody.ts
@@ -1,4 +1,3 @@
-import { Concat } from "../../Concat";
 import { InputState } from "../../InputState";
 import { MatchingLogic } from "../../Matchers";
 import { MatchPrefixResult } from "../../MatchPrefixResult";
@@ -9,6 +8,7 @@ import {
     TerminalPatternMatch,
     TreePatternMatch,
 } from "../../PatternMatch";
+import { Concat } from "../Concat";
 
 import { inputStateFromString } from "../../internal/InputStateFactory";
 

--- a/src/matchers/java/JavaBody.ts
+++ b/src/matchers/java/JavaBody.ts
@@ -31,11 +31,11 @@ class JavaBody implements MatchingLogic {
         }
     }
 
-    public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
+    public matchPrefix(is: InputState): MatchPrefixResult {
         const sm = new JavaContentStateMachine();
         let depth = 1;
         if (is.exhausted()) {
-            return matchPrefixSuccess(new TerminalPatternMatch(this.$id, "", is.offset, is, context));
+            return matchPrefixSuccess(new TerminalPatternMatch(this.$id, "", is.offset, is));
         }
 
         let currentIs = is;
@@ -70,12 +70,11 @@ class JavaBody implements MatchingLogic {
                 this.$id,
                 matched,
                 is.offset,
-                matched,
-                context));
+                matched));
         }
 
         // We supply the offset to preserve it in this match
-        return this.inner.matchPrefix(inputStateFromString(matched, is.offset), context);
+        return this.inner.matchPrefix(inputStateFromString(matched, is.offset));
     }
 }
 

--- a/src/matchers/java/JavaBody.ts
+++ b/src/matchers/java/JavaBody.ts
@@ -1,6 +1,6 @@
 import { InputState } from "../../InputState";
 import { MatchingLogic } from "../../Matchers";
-import { MatchPrefixResult } from "../../MatchPrefixResult";
+import {MatchPrefixResult, matchPrefixSuccess, SuccessfulMatch} from "../../MatchPrefixResult";
 import { TerminalPatternMatch } from "../../PatternMatch";
 import { Concat } from "../Concat";
 
@@ -35,7 +35,7 @@ class JavaBody implements MatchingLogic {
         const sm = new JavaContentStateMachine();
         let depth = 1;
         if (is.exhausted()) {
-            return new TerminalPatternMatch(this.$id, "", is.offset, is, context);
+            return matchPrefixSuccess(new TerminalPatternMatch(this.$id, "", is.offset, is, context));
         }
 
         let currentIs = is;
@@ -66,12 +66,12 @@ class JavaBody implements MatchingLogic {
             }
         }
         if (!this.inner) {
-            return new TerminalPatternMatch(
+            return matchPrefixSuccess(new TerminalPatternMatch(
                 this.$id,
                 matched,
                 is.offset,
                 matched,
-                context);
+                context));
         }
 
         // We supply the offset to preserve it in this match

--- a/src/matchers/skip/Skip.ts
+++ b/src/matchers/skip/Skip.ts
@@ -25,6 +25,11 @@ export const RestOfInput: MatchingLogic = {
 };
 
 /**
+ * Match the rest of the current line
+ */
+export const RestOfLine: MatchingLogic = new Break("\n");
+
+/**
  * Match a string until the given logic. Wraps Break.
  * Binds the content until the break.
  */

--- a/src/matchers/skip/Skip.ts
+++ b/src/matchers/skip/Skip.ts
@@ -6,6 +6,7 @@ import { MatchingLogic } from "../../Matchers";
 import { Break } from "../snobol/Break";
 
 import { InputState } from "../../InputState";
+import {matchPrefixSuccess} from "../../MatchPrefixResult";
 import { TerminalPatternMatch } from "../../PatternMatch";
 
 /**
@@ -18,7 +19,8 @@ export const RestOfInput: MatchingLogic = {
 
     matchPrefix(is: InputState, context: {}) {
         const consumed = is.skipWhile(s => true, 1);
-        return new TerminalPatternMatch(this.$id, consumed.skipped, is.offset, consumed.skipped, context);
+        return matchPrefixSuccess(
+            new TerminalPatternMatch(this.$id, consumed.skipped, is.offset, consumed.skipped, context));
     },
 };
 

--- a/src/matchers/skip/Skip.ts
+++ b/src/matchers/skip/Skip.ts
@@ -11,16 +11,16 @@ import { TerminalPatternMatch } from "../../PatternMatch";
 
 /**
  * Match the rest of the input.
- * @type {{$id: string; matchPrefix: ((is:InputState, context:{})=>TerminalPatternMatch)}}
+ * @type {{$id: string; matchPrefix: ((is:InputState)}}
  */
 export const RestOfInput: MatchingLogic = {
 
     $id: "RestOfInput",
 
-    matchPrefix(is: InputState, context: {}) {
+    matchPrefix(is: InputState) {
         const consumed = is.skipWhile(s => true, 1);
         return matchPrefixSuccess(
-            new TerminalPatternMatch(this.$id, consumed.skipped, is.offset, consumed.skipped, context));
+            new TerminalPatternMatch(this.$id, consumed.skipped, is.offset, consumed.skipped));
     },
 };
 

--- a/src/matchers/snobol/Break.ts
+++ b/src/matchers/snobol/Break.ts
@@ -1,9 +1,9 @@
 
-import { toMatchingLogic } from "../../Concat";
 import { InputState } from "../../InputState";
 import { MatchingLogic } from "../../Matchers";
 import { MatchPrefixResult } from "../../MatchPrefixResult";
 import { isPatternMatch, MatchFailureReport, TerminalPatternMatch } from "../../PatternMatch";
+import { toMatchingLogic } from "../Concat";
 
 /**
  * Inspired by SNOBOL BREAK: http://www.snobol4.org/docs/burks/tutorial/ch4.htm

--- a/src/matchers/snobol/Break.ts
+++ b/src/matchers/snobol/Break.ts
@@ -37,33 +37,33 @@ export class Break implements MatchingLogic {
     // tslint:disable-next-line:member-ordering
     public $id = `Break[${this.breakOn}]`;
 
-    public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
+    public matchPrefix(is: InputState): MatchPrefixResult {
         if (is.exhausted()) {
-            return matchPrefixSuccess(new TerminalPatternMatch(this.$id, "", is.offset, is, context));
+            return matchPrefixSuccess(new TerminalPatternMatch(this.$id, "", is.offset, is));
         }
 
         let currentIs = is;
         let matched = "";
-        let terminalMatch: MatchPrefixResult = this.terminateOn.matchPrefix(currentIs, context);
+        let terminalMatch: MatchPrefixResult = this.terminateOn.matchPrefix(currentIs);
         while (!currentIs.exhausted() && !isSuccessfulMatch(terminalMatch)) { // if it fits, it sits
             // But we can't match the bad match if it's defined
             if (this.badMatcher) {
-                if (isSuccessfulMatch(this.badMatcher.matchPrefix(currentIs, context))) {
-                    return new MatchFailureReport(this.$id, is.offset, context);
+                if (isSuccessfulMatch(this.badMatcher.matchPrefix(currentIs))) {
+                    return new MatchFailureReport(this.$id, is.offset);
                 }
             }
             matched += currentIs.peek(1);
             currentIs = currentIs.advance();
             if (!currentIs.exhausted()) {
-                terminalMatch = this.terminateOn.matchPrefix(currentIs, context);
+                terminalMatch = this.terminateOn.matchPrefix(currentIs);
             }
         }
         // We have found the terminal if we get here
         if (this.consume && isSuccessfulMatch(terminalMatch)) {
             return matchPrefixSuccess(new TerminalPatternMatch(this.$id, matched + terminalMatch.match.$matched,
-                terminalMatch.$offset, terminalMatch.match.$matched, context));
+                terminalMatch.$offset, terminalMatch.match.$matched));
         }
-        return matchPrefixSuccess(new TerminalPatternMatch(this.$id, matched, is.offset, matched, context));
+        return matchPrefixSuccess(new TerminalPatternMatch(this.$id, matched, is.offset, matched));
     }
 }
 

--- a/src/matchers/snobol/Break.ts
+++ b/src/matchers/snobol/Break.ts
@@ -16,6 +16,7 @@ import {toMatchingLogic} from "../Concat";
 export class Break implements MatchingLogic {
 
     public terminateOn: MatchingLogic;
+
     private badMatcher: MatchingLogic;
 
     /**
@@ -61,7 +62,7 @@ export class Break implements MatchingLogic {
         // We have found the terminal if we get here
         if (this.consume && isSuccessfulMatch(terminalMatch)) {
             return matchPrefixSuccess(new TerminalPatternMatch(this.$id, matched + terminalMatch.match.$matched,
-                terminalMatch.$offset, terminalMatch.match.$matched));
+                terminalMatch.$offset, terminalMatch.match.$value));
         }
         return matchPrefixSuccess(new TerminalPatternMatch(this.$id, matched, is.offset, matched));
     }

--- a/src/matchers/snobol/Span.ts
+++ b/src/matchers/snobol/Span.ts
@@ -15,7 +15,7 @@ export class Span implements MatchingLogic {
     constructor(public characters: string) {
     }
 
-    public matchPrefix(is: InputState, context: {}): MatchPrefixResult {
+    public matchPrefix(is: InputState): MatchPrefixResult {
         let currentIs = is;
         let matched = "";
         while (!currentIs.exhausted() && this.characters.indexOf(currentIs.peek(1)) > -1) {
@@ -23,7 +23,7 @@ export class Span implements MatchingLogic {
             currentIs = currentIs.advance();
         }
         return (currentIs !== is) ?
-           matchPrefixSuccess(new TerminalPatternMatch(this.$id, matched, is.offset, currentIs, context) ) :
+           matchPrefixSuccess(new TerminalPatternMatch(this.$id, matched, is.offset, currentIs) ) :
             new MatchFailureReport(this.$id, is.offset, context);
     }
 }

--- a/src/matchers/snobol/Span.ts
+++ b/src/matchers/snobol/Span.ts
@@ -1,7 +1,7 @@
 import { InputState } from "../../InputState";
 import { MatchingLogic } from "../../Matchers";
-import { MatchPrefixResult } from "../../MatchPrefixResult";
-import { MatchFailureReport, TerminalPatternMatch } from "../../PatternMatch";
+import {MatchFailureReport, MatchPrefixResult, matchPrefixSuccess} from "../../MatchPrefixResult";
+import { TerminalPatternMatch } from "../../PatternMatch";
 
 /**
  * Inspired by Snobol SPAN: http://www.snobol4.org/docs/burks/tutorial/ch4.htm
@@ -23,7 +23,7 @@ export class Span implements MatchingLogic {
             currentIs = currentIs.advance();
         }
         return (currentIs !== is) ?
-            new TerminalPatternMatch(this.$id, matched, is.offset, currentIs, context) :
+           matchPrefixSuccess(new TerminalPatternMatch(this.$id, matched, is.offset, currentIs, context) ) :
             new MatchFailureReport(this.$id, is.offset, context);
     }
 }

--- a/test/AltTest.ts
+++ b/test/AltTest.ts
@@ -11,21 +11,21 @@ describe("Alt", () => {
     it("should not match when neither A or B matches", () => {
         const alt = new Alt("A", "B");
         const is = inputStateFromString("friday 14");
-        const m = alt.matchPrefix(is, {});
+        const m = alt.matchPrefix(is);
         assert(!isSuccessfulMatch(m));
     });
 
     it("should not match when none of many matches", () => {
         const alt = new Alt("A", "B", "C", "D", "Cat");
         const is = inputStateFromString("friday 14");
-        const m = alt.matchPrefix(is, {});
+        const m = alt.matchPrefix(is);
         assert(!isSuccessfulMatch(m));
     });
 
     it("should match when A matches", () => {
         const alt = new Alt("A", "B");
         const is = inputStateFromString("AB");
-        const m = alt.matchPrefix(is, {});
+        const m = alt.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -37,7 +37,7 @@ describe("Alt", () => {
     it("should match when B matches", () => {
         const alt = new Alt("A", "B");
         const is = inputStateFromString("BA");
-        const m = alt.matchPrefix(is, {});
+        const m = alt.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -49,7 +49,7 @@ describe("Alt", () => {
     it("should match when C matches", () => {
         const alt = new Alt("A", "B", "C");
         const is = inputStateFromString("CXY");
-        const m = alt.matchPrefix(is, {});
+        const m = alt.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             assert(m.$matched === "C");
         } else {
@@ -60,7 +60,7 @@ describe("Alt", () => {
     it("should match with 3 when early matcher matches", () => {
         const alt = new Alt("A", "B", "C");
         const is = inputStateFromString("AD");
-        const m = alt.matchPrefix(is, {});
+        const m = alt.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 

--- a/test/AltTest.ts
+++ b/test/AltTest.ts
@@ -1,8 +1,8 @@
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
 import assert = require("power-assert");
 import { fail } from "power-assert";
 
 import { Alt } from "../src/Ops";
-import { isPatternMatch } from "../src/PatternMatch";
 
 import { inputStateFromString } from "../src/internal/InputStateFactory";
 
@@ -12,35 +12,45 @@ describe("Alt", () => {
         const alt = new Alt("A", "B");
         const is = inputStateFromString("friday 14");
         const m = alt.matchPrefix(is, {});
-        assert(!isPatternMatch(m));
+        assert(!isSuccessfulMatch(m));
     });
 
     it("should not match when none of many matches", () => {
         const alt = new Alt("A", "B", "C", "D", "Cat");
         const is = inputStateFromString("friday 14");
         const m = alt.matchPrefix(is, {});
-        assert(!isPatternMatch(m));
+        assert(!isSuccessfulMatch(m));
     });
 
     it("should match when A matches", () => {
         const alt = new Alt("A", "B");
         const is = inputStateFromString("AB");
         const m = alt.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("should match when B matches", () => {
         const alt = new Alt("A", "B");
         const is = inputStateFromString("BA");
         const m = alt.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("should match when C matches", () => {
         const alt = new Alt("A", "B", "C");
         const is = inputStateFromString("CXY");
         const m = alt.matchPrefix(is, {});
-        if (isPatternMatch(m)) {
+        if (isSuccessfulMatch(m)) {
             assert(m.$matched === "C");
         } else {
             fail("No match");
@@ -51,7 +61,12 @@ describe("Alt", () => {
         const alt = new Alt("A", "B", "C");
         const is = inputStateFromString("AD");
         const m = alt.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
 });

--- a/test/BooleanTest.ts
+++ b/test/BooleanTest.ts
@@ -7,7 +7,7 @@ import { LowercaseBoolean } from "../src/Primitives";
 describe("LowercaseBoolean", () => {
 
     it("matches true", () => {
-        const pm = LowercaseBoolean.matchPrefix(inputStateFromString("true"), {}) as PatternMatch;
+        const pm = LowercaseBoolean.matchPrefix(inputStateFromString("true")) as PatternMatch;
         if (isSuccessfulMatch(pm)) {
                        const mmmm = pm.match as any;
                        assert(mmmm.$value);
@@ -18,7 +18,7 @@ describe("LowercaseBoolean", () => {
                    });
 
     it("matches false", () => {
-        const pm = LowercaseBoolean.matchPrefix(inputStateFromString("false"), {}) as PatternMatch;
+        const pm = LowercaseBoolean.matchPrefix(inputStateFromString("false")) as PatternMatch;
         if (isSuccessfulMatch(pm)) {
                        const mmmm = pm.match as any;
                        assert(!mmmm.$value);
@@ -29,7 +29,7 @@ describe("LowercaseBoolean", () => {
                    });
 
     it("doesn't match junk", () => {
-        const pm = LowercaseBoolean.matchPrefix(inputStateFromString("xyz"), {}) as PatternMatch;
+        const pm = LowercaseBoolean.matchPrefix(inputStateFromString("xyz")) as PatternMatch;
         assert(!isSuccessfulMatch(pm));
     });
 

--- a/test/BooleanTest.ts
+++ b/test/BooleanTest.ts
@@ -1,25 +1,36 @@
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
 import assert = require("power-assert");
 import { inputStateFromString } from "../src/internal/InputStateFactory";
-import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
+import {  PatternMatch } from "../src/PatternMatch";
 import { LowercaseBoolean } from "../src/Primitives";
 
 describe("LowercaseBoolean", () => {
 
     it("matches true", () => {
         const pm = LowercaseBoolean.matchPrefix(inputStateFromString("true"), {}) as PatternMatch;
-        assert(isPatternMatch(pm));
-        assert(pm.$value);
-    });
+        if (isSuccessfulMatch(pm)) {
+                       const mmmm = pm.match as any;
+                       assert(mmmm.$value);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("matches false", () => {
         const pm = LowercaseBoolean.matchPrefix(inputStateFromString("false"), {}) as PatternMatch;
-        assert(isPatternMatch(pm));
-        assert(!pm.$value);
-    });
+        if (isSuccessfulMatch(pm)) {
+                       const mmmm = pm.match as any;
+                       assert(!mmmm.$value);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("doesn't match junk", () => {
         const pm = LowercaseBoolean.matchPrefix(inputStateFromString("xyz"), {}) as PatternMatch;
-        assert(!isPatternMatch(pm));
+        assert(!isSuccessfulMatch(pm));
     });
 
 });

--- a/test/ConcatTest.ts
+++ b/test/ConcatTest.ts
@@ -190,6 +190,26 @@ describe("Concat", () => {
         expect(r.hobbies).to.have.members(["golf", "tweeting"]);
     });
 
-    it("does not allow undefined matcher fields");
+    it("does not allow undefined matcher field steps", () => {
+        const literal: string = undefined;
+        assert.throws(() => new Concat({
+            opening: literal,
+            thing: "thing",
+        }), e => {
+            assert(e.message.indexOf("Step [opening] is undefined") !== -1);
+            return true;
+        });
+    });
+
+    it("does not allow null matcher field steps", () => {
+        const literal: string = null;
+        assert.throws(() => new Concat({
+            opening: literal,
+            thing: "thing",
+        }), e => {
+            assert(e.message.indexOf("Step [opening] is null") !== -1);
+            return true;
+        });
+    });
 
 });

--- a/test/ConcatTest.ts
+++ b/test/ConcatTest.ts
@@ -190,4 +190,6 @@ describe("Concat", () => {
         expect(r.hobbies).to.have.members(["golf", "tweeting"]);
     });
 
+    it("does not allow undefined matcher fields");
+
 });

--- a/test/ContextTest.ts
+++ b/test/ContextTest.ts
@@ -81,7 +81,7 @@ describe("ContextTest", () => {
     it("handles nested matches", () => {
         const cc = new Concat({
             nested: {
-                name: /^[a-z]+/,
+                name: /[a-z]+/,
             },
             promote(ctx) { ctx.promoted = ctx.nested.name; },
             b: Integer,
@@ -95,7 +95,7 @@ describe("ContextTest", () => {
     it("handles multiple bound matches in microgrammar", () => {
         const cc = Microgrammar.fromDefinitions({
             nested: {
-                name: /^[a-z]+/,
+                name: /[a-z]+/,
             },
             promoted: ctx => ctx.nested.name,
             b: Integer,
@@ -110,7 +110,7 @@ describe("ContextTest", () => {
     it("doesn't pollute parent context in microgrammar", () => {
         const cc = Microgrammar.fromDefinitions({
             nested: {
-                name: /^[a-z]+/,
+                name: /[a-z]+/,
                 shouty: ctx => ctx.name.toLocaleUpperCase(),
             },
             b: Integer,
@@ -125,7 +125,7 @@ describe("ContextTest", () => {
     it("handles nested bound matches in microgrammar", () => {
         const cc = Microgrammar.fromDefinitions({
             nested: {
-                name: /^[a-z]+/,
+                name: /[a-z]+/,
                 shouty: ctx => ctx.name.toLocaleUpperCase(),
             },
             b: Integer,

--- a/test/ContextTest.ts
+++ b/test/ContextTest.ts
@@ -1,6 +1,6 @@
 import * as assert from "power-assert";
-import { Concat } from "../src/Concat";
 import { inputStateFromString } from "../src/internal/InputStateFactory";
+import { Concat } from "../src/matchers/Concat";
 import { Microgrammar } from "../src/Microgrammar";
 import { isPatternMatch } from "../src/PatternMatch";
 import { Integer, LowercaseBoolean } from "../src/Primitives";

--- a/test/ContextTest.ts
+++ b/test/ContextTest.ts
@@ -1,9 +1,10 @@
 import * as assert from "power-assert";
-import { inputStateFromString } from "../src/internal/InputStateFactory";
-import { Concat } from "../src/matchers/Concat";
-import { Microgrammar } from "../src/Microgrammar";
-import { isPatternMatch } from "../src/PatternMatch";
-import { Integer, LowercaseBoolean } from "../src/Primitives";
+import {inputStateFromString} from "../src/internal/InputStateFactory";
+import {Concat} from "../src/matchers/Concat";
+import {isSuccessfulMatch, SuccessfulMatch} from "../src/MatchPrefixResult";
+import {Microgrammar} from "../src/Microgrammar";
+
+import {Integer, LowercaseBoolean} from "../src/Primitives";
 
 describe("ContextTest", () => {
 
@@ -13,7 +14,7 @@ describe("ContextTest", () => {
             b: Integer,
             sum: ctx => ctx.a + ctx.b,
         });
-        const matched: any = cc.matchPrefix(inputStateFromString("24 7"), {});
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
         assert(matched.sum === 24 + 7);
@@ -26,7 +27,7 @@ describe("ContextTest", () => {
             willBeFalse: ctx => typeof ctx.a === "string",
             sum: ctx => ctx.a + ctx.b,
         });
-        const matched: any = cc.matchPrefix(inputStateFromString("24 7"), {});
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
         assert(matched.sum === 24 + 7);
@@ -38,7 +39,7 @@ describe("ContextTest", () => {
             b: Integer,
             sum: ctx => ctx.a + ctx.b,
         });
-        const matched: any = cc.matchPrefix(inputStateFromString("24 7"), {});
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
         assert(matched.sum === 24 + 7);
@@ -48,9 +49,11 @@ describe("ContextTest", () => {
         const cc = new Concat({
             a: Integer,
             b: /[0-9]+/,
-            _rework(ctx) { ctx.b = parseInt(ctx.b, 10); },
+            _rework(ctx) {
+                ctx.b = parseInt(ctx.b, 10);
+            },
         });
-        const matched: any = cc.matchPrefix(inputStateFromString("24 7"), {});
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
     });
@@ -60,7 +63,7 @@ describe("ContextTest", () => {
             a: Integer,
             b: [/[0-9]+/, b => parseInt(b, 10)],
         });
-        const matched: any = cc.matchPrefix(inputStateFromString("24 7"), {});
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
     });
@@ -68,14 +71,16 @@ describe("ContextTest", () => {
     it("use function to dictate match", () => {
         const cc = new Concat({
             flag: LowercaseBoolean,
-            _done(ctx) { return ctx.flag; },
+            _done(ctx) {
+                return ctx.flag;
+            },
             b: Integer,
             c: Integer,
         });
         const matched = cc.matchPrefix(inputStateFromString("true 7 35"), {});
-        assert(isPatternMatch(matched));
+        assert(isSuccessfulMatch(matched));
         const matched2 = cc.matchPrefix(inputStateFromString("false 7 35"), {});
-        assert(!isPatternMatch(matched2));
+        assert(!isSuccessfulMatch(matched2));
     });
 
     it("handles nested matches", () => {
@@ -83,12 +88,13 @@ describe("ContextTest", () => {
             nested: {
                 name: /[a-z]+/,
             },
-            promote(ctx) { ctx.promoted = ctx.nested.name; },
+            promote(ctx) {
+                ctx.promoted = ctx.nested.name;
+            },
             b: Integer,
             c: Integer,
         });
-        const matched = cc.matchPrefix(inputStateFromString("gary 7 35"), {});
-        assert(isPatternMatch(matched));
+        const matched = (cc.matchPrefix(inputStateFromString("gary 7 35"), {}) as SuccessfulMatch).match;
         assert((matched as any).promoted === "gary");
     });
 

--- a/test/ContextTest.ts
+++ b/test/ContextTest.ts
@@ -61,7 +61,8 @@ describe("ContextTest", () => {
     it("rewrites property using transformation", () => {
         const cc = new Concat({
             a: Integer,
-            b: [/[0-9]+/, b => parseInt(b, 10)],
+            stringB: /[0-9]+/,
+            b: ctx => parseInt(ctx.stringB, 10),
         });
         const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
         assert(matched.a === 24);

--- a/test/ContextTest.ts
+++ b/test/ContextTest.ts
@@ -14,7 +14,7 @@ describe("ContextTest", () => {
             b: Integer,
             sum: ctx => ctx.a + ctx.b,
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
         assert(matched.sum === 24 + 7);
@@ -27,7 +27,7 @@ describe("ContextTest", () => {
             willBeFalse: ctx => typeof ctx.a === "string",
             sum: ctx => ctx.a + ctx.b,
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
         assert(matched.sum === 24 + 7);
@@ -39,7 +39,7 @@ describe("ContextTest", () => {
             b: Integer,
             sum: ctx => ctx.a + ctx.b,
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
         assert(matched.sum === 24 + 7);
@@ -53,7 +53,7 @@ describe("ContextTest", () => {
                 ctx.b = parseInt(ctx.b, 10);
             },
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
     });
@@ -64,7 +64,7 @@ describe("ContextTest", () => {
             stringB: /[0-9]+/,
             b: ctx => parseInt(ctx.stringB, 10),
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
     });
@@ -78,9 +78,9 @@ describe("ContextTest", () => {
             b: Integer,
             c: Integer,
         });
-        const matched = cc.matchPrefix(inputStateFromString("true 7 35"), {});
+        const matched = cc.matchPrefix(inputStateFromString("true 7 35"));
         assert(isSuccessfulMatch(matched));
-        const matched2 = cc.matchPrefix(inputStateFromString("false 7 35"), {});
+        const matched2 = cc.matchPrefix(inputStateFromString("false 7 35"));
         assert(!isSuccessfulMatch(matched2));
     });
 
@@ -95,7 +95,7 @@ describe("ContextTest", () => {
             b: Integer,
             c: Integer,
         });
-        const matched = (cc.matchPrefix(inputStateFromString("gary 7 35"), {}) as SuccessfulMatch).match;
+        const matched = (cc.matchPrefix(inputStateFromString("gary 7 35")) as SuccessfulMatch).match;
         assert((matched as any).promoted === "gary");
     });
 

--- a/test/FloatTest.ts
+++ b/test/FloatTest.ts
@@ -1,52 +1,80 @@
-import { expect } from "chai";
-import { inputStateFromString } from "../src/internal/InputStateFactory";
-import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
-import { Float } from "../src/Primitives";
+import {expect} from "chai";
+import {inputStateFromString} from "../src/internal/InputStateFactory";
+import {isSuccessfulMatch} from "../src/MatchPrefixResult";
+import {PatternMatch} from "../src/PatternMatch";
+import {Float} from "../src/Primitives";
+
+import * as assert from "power-assert";
 
 describe("Float", () => {
 
     it("test one digit", () => {
         const is = inputStateFromString("1");
         const m = Float.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        const match = m as PatternMatch;
-        expect(match.$matched).to.equal("1");
-        expect(match.$value).to.equal(1.0);
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            const match = mmmm as PatternMatch;
+            expect(match.$matched).to.equal("1");
+            expect(match.$value).to.equal(1.0);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("test multiple digits", () => {
         const is = inputStateFromString("105x");
         const m = Float.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        const match = m as PatternMatch;
-        expect(match.$matched).to.equal("105");
-        expect(match.$value).to.equal(105.0);
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            const match = mmmm as PatternMatch;
+            expect(match.$matched).to.equal("105");
+            expect(match.$value).to.equal(105.0);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("test with decimal", () => {
         const is = inputStateFromString("105.25555xxx");
         const m = Float.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        const match = m as PatternMatch;
-        expect(match.$matched).to.equal("105.25555");
-        expect(match.$value).to.equal(105.25555);
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            const match = mmmm as PatternMatch;
+            expect(match.$matched).to.equal("105.25555");
+            expect(match.$value).to.equal(105.25555);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("test signed", () => {
         const is = inputStateFromString("-105.25555xxx");
         const m = Float.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        const match = m as PatternMatch;
-        expect(match.$matched).to.equal("-105.25555");
-        expect(match.$value).to.equal(-105.25555);
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            const match = mmmm as PatternMatch;
+            expect(match.$matched).to.equal("-105.25555");
+            expect(match.$value).to.equal(-105.25555);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("test no leading digit", () => {
         const is = inputStateFromString("-.25555xxx");
         const m = Float.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        const match = m as PatternMatch;
-        expect(match.$matched).to.equal("-.25555");
-        expect(match.$value).to.equal(-0.25555);
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            const match = mmmm as PatternMatch;
+            expect(match.$matched).to.equal("-.25555");
+            expect(match.$value).to.equal(-0.25555);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 });

--- a/test/FloatTest.ts
+++ b/test/FloatTest.ts
@@ -10,7 +10,7 @@ describe("Float", () => {
 
     it("test one digit", () => {
         const is = inputStateFromString("1");
-        const m = Float.matchPrefix(is, {});
+        const m = Float.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;
@@ -24,7 +24,7 @@ describe("Float", () => {
 
     it("test multiple digits", () => {
         const is = inputStateFromString("105x");
-        const m = Float.matchPrefix(is, {});
+        const m = Float.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;
@@ -38,7 +38,7 @@ describe("Float", () => {
 
     it("test with decimal", () => {
         const is = inputStateFromString("105.25555xxx");
-        const m = Float.matchPrefix(is, {});
+        const m = Float.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;
@@ -52,7 +52,7 @@ describe("Float", () => {
 
     it("test signed", () => {
         const is = inputStateFromString("-105.25555xxx");
-        const m = Float.matchPrefix(is, {});
+        const m = Float.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;
@@ -66,7 +66,7 @@ describe("Float", () => {
 
     it("test no leading digit", () => {
         const is = inputStateFromString("-.25555xxx");
-        const m = Float.matchPrefix(is, {});
+        const m = Float.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;

--- a/test/IntegerTest.ts
+++ b/test/IntegerTest.ts
@@ -24,7 +24,7 @@ describe("Integer matching", () => {
 
     it("test one digit", () => {
         const is = inputStateFromString("1");
-        const m = Integer.matchPrefix(is, {});
+        const m = Integer.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        const match = mmmm;
@@ -38,7 +38,7 @@ describe("Integer matching", () => {
 
     it("test multiple digits", () => {
         const is = inputStateFromString("105x");
-        const m = Integer.matchPrefix(is, {});
+        const m = Integer.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        const match = mmmm;

--- a/test/IntegerTest.ts
+++ b/test/IntegerTest.ts
@@ -1,5 +1,6 @@
 import { inputStateFromString } from "../src/internal/InputStateFactory";
-import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
+import {  PatternMatch } from "../src/PatternMatch";
 import { Integer } from "../src/Primitives";
 
 import * as assert from "power-assert";
@@ -24,19 +25,29 @@ describe("Integer matching", () => {
     it("test one digit", () => {
         const is = inputStateFromString("1");
         const m = Integer.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        const match = m as PatternMatch;
-        assert(match.$matched === "1");
-        assert(match.$value === 1);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       const match = mmmm;
+                       assert(match.$matched === "1");
+                       assert(match.$value === 1);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("test multiple digits", () => {
         const is = inputStateFromString("105x");
         const m = Integer.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        const match = m as PatternMatch;
-        assert(match.$matched === "105");
-        assert(match.$value === 105);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       const match = mmmm;
+                       assert(match.$matched === "105");
+                       assert(match.$value === 105);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
 });

--- a/test/MatchingMachineTest.ts
+++ b/test/MatchingMachineTest.ts
@@ -20,7 +20,7 @@ describe("MatchingMachine", () => {
 
             constructor() {
                 super({
-                    name: /^[A-Z][a-z]+/,
+                    name: /[A-Z][a-z]+/,
                 });
                 // console.log("The matcher is " + JSON.stringify(this.matcher))
             }
@@ -48,7 +48,7 @@ describe("MatchingMachine", () => {
 
             constructor() {
                 super({
-                    name: /^[A-Za-z]+/,
+                    name: /[A-Za-z]+/,
                 });
 
             }
@@ -56,7 +56,7 @@ describe("MatchingMachine", () => {
             protected onMatch(pm: PatternMatch): any {
                 this.matches.push(pm);
                 return {
-                    number: /^[0-9]+/,
+                    number: /[0-9]+/,
                 };
             }
         }
@@ -70,15 +70,15 @@ describe("MatchingMachine", () => {
 
     const pyClass = {
         _class: "class",
-        name: /^[A-Za-z]+/,
+        name: /[A-Za-z]+/,
         _sep: ":",
     };
 
     const pyMethod = {
         _def: "def",
-        name: /^[a-z]+/,
+        name: /[a-z]+/,
         _lp: "(",
-        args: /^[^)]*/,
+        args: /[^)]*/,
         _rp: ")",
         _sep: ":",
     };

--- a/test/MatchingMachineTest.ts
+++ b/test/MatchingMachineTest.ts
@@ -221,7 +221,8 @@ export class XmlTracker extends MatchingMachine {
         return this.matcher;
     }
 
-    protected observeMatch(pm: { name: string, slash }) {
+    protected observeMatch(patternMatch) {
+        const pm: { name: string, slash } = patternMatch as any;
         if (pm.slash) {
             this.elementStack.pop();
             if (pm.name === "dependency") {

--- a/test/MavenGrammars.ts
+++ b/test/MavenGrammars.ts
@@ -42,7 +42,8 @@ export const ALL_DEPENDENCY_GRAMMAR =
         lx: "<artifactId>",
         artifact: LEGAL_VALUE,
         rx: "</artifactId>",
-        version: new Opt(VERSION, "version"),
+        _version: new Opt(VERSION),
+        version: ctx => ctx._version ? ctx._version.version : undefined
     });
 
 export const PLUGIN_GRAMMAR = Microgrammar.fromDefinitions<VersionedArtifact>({
@@ -69,7 +70,8 @@ export const ALL_PLUGIN_GRAMMAR =
         lx: "<artifactId>",
         artifact: LEGAL_VALUE,
         rx: "</artifactId>",
-        version: new Opt(VERSION, "version"),
+        _version: new Opt(VERSION),
+        version: ctx => ctx._version ? ctx._version.version : undefined
     });
 
 const property = {

--- a/test/MavenGrammars.ts
+++ b/test/MavenGrammars.ts
@@ -43,7 +43,7 @@ export const ALL_DEPENDENCY_GRAMMAR =
         artifact: LEGAL_VALUE,
         rx: "</artifactId>",
         _version: new Opt(VERSION),
-        version: ctx => ctx._version ? ctx._version.version : undefined
+        version: ctx => ctx._version ? ctx._version.version : undefined,
     });
 
 export const PLUGIN_GRAMMAR = Microgrammar.fromDefinitions<VersionedArtifact>({
@@ -71,7 +71,7 @@ export const ALL_PLUGIN_GRAMMAR =
         artifact: LEGAL_VALUE,
         rx: "</artifactId>",
         _version: new Opt(VERSION),
-        version: ctx => ctx._version ? ctx._version.version : undefined
+        version: ctx => ctx._version ? ctx._version.version : undefined,
     });
 
 const property = {

--- a/test/MavenGrammars.ts
+++ b/test/MavenGrammars.ts
@@ -10,7 +10,7 @@ export interface VersionedArtifact {
     version: string;
 }
 
-export const LEGAL_VALUE = /^[a-zA-Z_\.0-9\-]+/;
+export const LEGAL_VALUE = /[a-zA-Z_\.0-9\-]+/;
 
 const VERSION = {
     lx2: "<version>",
@@ -76,7 +76,7 @@ const property = {
     _gt: "<",
     name: LEGAL_VALUE,
     _close: ">",
-    value: /^[^<]+/,
+    value: /[^<]+/,
     _gt2: "</",
     _closing: LEGAL_VALUE,
     _done: ">",

--- a/test/MavenGrammars.ts
+++ b/test/MavenGrammars.ts
@@ -1,5 +1,5 @@
-import { Concat } from "../src/Concat";
 import { Term } from "../src/Matchers";
+import { Concat } from "../src/matchers/Concat";
 import { Microgrammar } from "../src/Microgrammar";
 import { Opt, when } from "../src/Ops";
 import { Rep, Rep1 } from "../src/Rep";

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -177,13 +177,15 @@ describe("Microgrammar", () => {
 
     it("2 XML elements with intervening whitespace and leading junk via microgrammar", () => {
         // tslint:disable-next-line:max-line-length
-        testTwoXmlElements("and this is a load of nonsense we don't care about <foo>   <bar> who cares about this hunk of junk",
+        testTwoXmlElements(
+            "and this is a load of nonsense we don't care about <foo>   <bar> who cares about this hunk of junk",
             "foo", "bar");
     });
 
     it("2 XML elements with intervening whitespace and junk and leading junk via microgrammar", () => {
         // tslint:disable-next-line:max-line-length
-        testTwoXmlElements("and this is a load of nonsense we don't care about <foo> and SO **** 7&&@#$@#$ is this  <bar> who cares about this hunk of junk",
+        testTwoXmlElements(
+            "and this is a load of nonsense we don't care about <foo> and SO **** 7&&@#$@#$ is this  <bar> who cares about this hunk of junk",
             "foo", "bar");
     });
 
@@ -312,14 +314,15 @@ describe("Microgrammar", () => {
         const nameMatch = r0.second.$valueMatches.name as PatternMatch;
 
         for (const p in r0.second) {
-            console.log(`property ${p}:`)
-            console.log(`[${JSON.stringify(r0.second[p])}]`)
+            if ("tslint wants an if") {
+                console.log(`property ${p}:`);
+                console.log(`[${JSON.stringify(r0.second[p])}]`);
+            }
         }
 
-
-        console.log(`yo [${JSON.stringify(r0.second)}]`)
+        console.log(`yo [${JSON.stringify(r0.second)}]`);
         assert(nameMatch.$value === "second");
-        console.log("not yo")
+        console.log("not yo");
         assert(nameMatch.$matched === nameMatch.$value);
         assert(nameMatch.$offset === "<first><".length);
     });

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -557,42 +557,6 @@ class StringGrammar {
 
 }
 
-describe("StringGrammarTest", () => {
-
-    it("string found in alt", () => {
-        const strings = Microgrammar.fromDefinitions<any>(
-            {stringOrLa: new Alt(StringGrammar.stringGrammar, "la")}).findMatches('"winter is coming" la la la');
-        assert(isPatternMatch(strings[0]));
-        assert(strings[0].$matched === '"winter is coming"');
-        const match = strings[0].matchedStructure();
-        assert(match.stringOrLa.text, "winter is coming");
-    });
-
-    it("string found", () => {
-        const strings = Microgrammar.fromDefinitions<any>(
-            {stringOrLa: StringGrammar.stringGrammar}).findMatches('"winter is coming"');
-        const match = strings[0];
-        if (isPatternMatch(match)) {
-            console.log("Thes match is " + JSON.stringify(match))
-            const mmmm = match as any;
-            assert(mmmm.stringOrLa.$matched === '"winter is coming"');
-            assert(mmmm.$matched === '"winter is coming"');
-            assert(mmmm.stringOrLa.text, "winter is coming");
-
-        } else {
-            assert.fail("Didn't match");
-        }
-    });
-
-    it("string found with escaped quotes", () => {
-            const strings = StringGrammar.stringGrammar.findMatches("\"winter is \\\"coming\\\"\"  ");
-            const match = strings[0];
-            assert(match.$matched === "\"winter is \\\"coming\\\"\"");
-            assert(match.text === "winter is \\\"coming\\\"");
-        },
-    );
-});
-
 interface CatsDogsAndPigs {
     dogs: string[];
     cats: string[];

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -573,6 +573,7 @@ describe("StringGrammarTest", () => {
             {stringOrLa: StringGrammar.stringGrammar}).findMatches('"winter is coming"');
         const match = strings[0];
         if (isPatternMatch(match)) {
+            console.log("Thes match is " + JSON.stringify(match))
             const mmmm = match as any;
             assert(mmmm.stringOrLa.$matched === '"winter is coming"');
             assert(mmmm.$matched === '"winter is coming"');

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -309,7 +309,7 @@ describe("Microgrammar", () => {
         assert(r0.first.$matched === "<first>");
         assert(r0.second.name === "second");
         // Now access match for the name
-        const nameMatch = r0.second.$value.name$match as PatternMatch;
+        const nameMatch = r0.second.$valueMatches.name as PatternMatch;
 
         for (const p in r0.second) {
             console.log(`property ${p}:`)

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -306,11 +306,20 @@ describe("Microgrammar", () => {
         const r0 = result[0] as any;
         assert(result[0].$matched === content);
         assert(r0.first.name === "first");
-        assert(r0.first.$match.$matched === "<first>");
+        assert(r0.first.$matched === "<first>");
         assert(r0.second.name === "second");
         // Now access match for the name
-        const nameMatch = r0.second.name$match as PatternMatch;
+        const nameMatch = r0.second.$value.name$match as PatternMatch;
+
+        for (const p in r0.second) {
+            console.log(`property ${p}:`)
+            console.log(`[${JSON.stringify(r0.second[p])}]`)
+        }
+
+
+        console.log(`yo [${JSON.stringify(r0.second)}]`)
         assert(nameMatch.$value === "second");
+        console.log("not yo")
         assert(nameMatch.$matched === nameMatch.$value);
         assert(nameMatch.$offset === "<first><".length);
     });
@@ -327,13 +336,12 @@ describe("Microgrammar", () => {
             second: new Opt(element),
         });
         const result = mg.findMatches(content);
-        // console.log("Result is " + JSON.stringify(result));
         expect(result.length).to.equal(1);
         const r0 = result[0] as any;
-        // expect(r0.$name).to.equal("element");
+        assert(isPatternMatch(r0));
         assert(r0.$matched === content);
-        assert(r0.first.$match);
-        assert(r0.first.$match.$matched === "<first>");
+        assert(r0.first);
+        assert(r0.first.$matched === "<first>");
         assert(r0.second === undefined);
     });
 
@@ -356,7 +364,7 @@ describe("Microgrammar", () => {
         const r0 = result[0] as any;
         expect(r0.$name).to.equal("element");
         expect(r0.$matched).to.equal(content);
-        expect(r0.first.$match.$matched).to.equal("<first>");
+        expect(r0.first.$matched).to.equal("<first>");
         expect(r0.first.name).to.equal("first");
         expect(r0.second.name).to.equal("second");
     });
@@ -555,8 +563,8 @@ describe("StringGrammarTest", () => {
         const strings = Microgrammar.fromDefinitions<any>(
             {stringOrLa: new Alt(StringGrammar.stringGrammar, "la")}).findMatches('"winter is coming" la la la');
         assert(isPatternMatch(strings[0]));
+        assert(strings[0].$matched === '"winter is coming"');
         const match = strings[0].matchedStructure();
-        assert(match.$matched === '"winter is coming"');
         assert(match.stringOrLa.text, "winter is coming");
     });
 
@@ -566,8 +574,8 @@ describe("StringGrammarTest", () => {
         const match = strings[0];
         if (isPatternMatch(match)) {
             const mmmm = match as any;
+            assert(mmmm.stringOrLa.$matched === '"winter is coming"');
             assert(mmmm.$matched === '"winter is coming"');
-            console.log(JSON.stringify(mmmm.stringOrLa));
             assert(mmmm.stringOrLa.text, "winter is coming");
 
         } else {

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -259,7 +259,7 @@ describe("Microgrammar", () => {
             name: string;
         }
         const mg = Microgrammar.fromDefinitions<Named>({
-            name: /^[A-Z][a-z]+/,
+            name: /[A-Z][a-z]+/,
         });
         const result = mg.findMatches("Emmanuel Marine");
         expect(result.length).to.equal(2);
@@ -278,7 +278,7 @@ describe("Microgrammar", () => {
             name: string;
         }
         const mg = Microgrammar.fromDefinitions<Named>({
-            name: /^[A-Z][a-z]+/,
+            name: /[A-Z][a-z]+/,
         });
         const result = mg.findMatches("Emmanuel Marine");
         expect(result.length).to.equal(2);
@@ -450,7 +450,7 @@ describe("Microgrammar", () => {
     });
 
     it("microgrammars can compose: no match", () => {
-        const names = new Rep1Sep(/^[a-zA-Z0-9]+/, ",");
+        const names = new Rep1Sep(/[a-zA-Z0-9]+/, ",");
         const nested = Microgrammar.fromDefinitions({
             pigs: names,
         });
@@ -508,7 +508,7 @@ describe("Microgrammar", () => {
     });
 
     it("opt is flattened and returns undefined", () => {
-        const names = new Rep1Sep(/^[a-zA-Z0-9]+/, ",");
+        const names = new Rep1Sep(/[a-zA-Z0-9]+/, ",");
         const nested = Microgrammar.fromDefinitions({
             pigs: names,
         });

--- a/test/OptTest.ts
+++ b/test/OptTest.ts
@@ -80,7 +80,8 @@ describe("Opt", () => {
             } as Term,
         );
         const mg = Microgrammar.fromDefinitions({
-                x: new Ogpt(nested, "x"),
+                _x: new Opt(nested),
+            x: ctx => ctx._x.x,
                 $id: "x",
             } as Term,
         );

--- a/test/OptTest.ts
+++ b/test/OptTest.ts
@@ -14,7 +14,7 @@ describe("Opt", () => {
     it("should match when matcher doesn't match", () => {
         const alt = new Opt("A");
         const is = inputStateFromString("friday 14");
-        const m = alt.matchPrefix(is, {}) as PatternMatch;
+        const m = alt.matchPrefix(is) as PatternMatch;
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             expect(mmmm.$value).to.equal(undefined);
@@ -27,7 +27,7 @@ describe("Opt", () => {
     it("should match when matcher matches", () => {
         const alt = new Opt("A");
         const is = inputStateFromString("AB");
-        const m = alt.matchPrefix(is, {}) as PatternMatch;
+        const m = alt.matchPrefix(is) as PatternMatch;
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             expect(mmmm.$value).to.equal("A");
@@ -41,7 +41,7 @@ describe("Opt", () => {
         const content = "";
         const mg = new Opt(new Literal("x"));
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as PatternMatch;
+        const result = mg.matchPrefix(is) as PatternMatch;
         // console.log(JSON.stringify(result));
         expect(result.$matched).to.equal("");
     });
@@ -50,7 +50,7 @@ describe("Opt", () => {
         const content = "x";
         const mg = new Opt(new Literal("x"));
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as PatternMatch;
+        const result = mg.matchPrefix(is) as PatternMatch;
         // console.log(JSON.stringify(result));
         expect(result.$matched).to.equal("x");
     });
@@ -80,7 +80,7 @@ describe("Opt", () => {
             } as Term,
         );
         const mg = Microgrammar.fromDefinitions({
-                x: new Opt(nested, "x"),
+                x: new Ogpt(nested, "x"),
                 $id: "x",
             } as Term,
         );

--- a/test/OptTest.ts
+++ b/test/OptTest.ts
@@ -1,10 +1,13 @@
-import { expect } from "chai";
-import { inputStateFromString } from "../src/internal/InputStateFactory";
-import { Term } from "../src/Matchers";
-import { Microgrammar } from "../src/Microgrammar";
-import { Opt } from "../src/Ops";
-import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
-import { Literal } from "../src/Primitives";
+import {expect} from "chai";
+import {inputStateFromString} from "../src/internal/InputStateFactory";
+import {Term} from "../src/Matchers";
+import {isSuccessfulMatch} from "../src/MatchPrefixResult";
+import {Microgrammar} from "../src/Microgrammar";
+import {Opt} from "../src/Ops";
+import {PatternMatch} from "../src/PatternMatch";
+import {Literal} from "../src/Primitives";
+
+import * as assert from "power-assert";
 
 describe("Opt", () => {
 
@@ -12,16 +15,26 @@ describe("Opt", () => {
         const alt = new Opt("A");
         const is = inputStateFromString("friday 14");
         const m = alt.matchPrefix(is, {}) as PatternMatch;
-        expect(isPatternMatch(m)).to.equal(true);
-        expect(m.$value).to.equal(undefined);
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            expect(mmmm.$value).to.equal(undefined);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("should match when matcher matches", () => {
         const alt = new Opt("A");
         const is = inputStateFromString("AB");
         const m = alt.matchPrefix(is, {}) as PatternMatch;
-        expect(isPatternMatch(m)).to.equal(true);
-        expect(m.$value).to.equal("A");
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            expect(mmmm.$value).to.equal("A");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("test raw opt missing", () => {
@@ -45,14 +58,14 @@ describe("Opt", () => {
     it("not pull up single property", () => {
         const content = "x";
         const nested = Microgrammar.fromDefinitions({
-            x: new Literal("x"),
-            $id: "xx",
-        } as Term,
+                x: new Literal("x"),
+                $id: "xx",
+            } as Term,
         );
         const mg = Microgrammar.fromDefinitions({
-            x: new Opt(nested),
-            $id: "x",
-        } as Term,
+                x: new Opt(nested),
+                $id: "x",
+            } as Term,
         );
 
         const result = mg.firstMatch(content) as any;
@@ -62,14 +75,14 @@ describe("Opt", () => {
     it("pull up single property", () => {
         const content = "x";
         const nested = Microgrammar.fromDefinitions({
-            x: new Literal("x"),
-            $id: "xx",
-        } as Term,
+                x: new Literal("x"),
+                $id: "xx",
+            } as Term,
         );
         const mg = Microgrammar.fromDefinitions({
-            x: new Opt(nested, "x"),
-            $id: "x",
-        } as Term,
+                x: new Opt(nested, "x"),
+                $id: "x",
+            } as Term,
         );
 
         const result = mg.firstMatch(content) as any;

--- a/test/PositioningTest.ts
+++ b/test/PositioningTest.ts
@@ -19,7 +19,7 @@ describe("Positioning", () => {
             assert(m);
             assert(m.startElement);
             // console.log(JSON.stringify(m.startElement));
-            assert(m.$value.startElement$match);
+            assert(m.$valueMatches.startElement);
         });
     });
 });

--- a/test/RegexTest.ts
+++ b/test/RegexTest.ts
@@ -13,7 +13,7 @@ describe("Regex", () => {
     it("match word letters", () => {
         const regexp = new Regex(/[a-z]+/);
         const is = inputStateFromString("friday 14");
-        const m = regexp.matchPrefix(is, {});
+        const m = regexp.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        const match = mmmm;
@@ -27,7 +27,7 @@ describe("Regex", () => {
     it("match word letters using anchor that will be recognized", () => {
         const regexp = new Regex(/[a-z]+/);
         const is = inputStateFromString("friday 14");
-        const m = regexp.matchPrefix(is, {});
+        const m = regexp.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        const match = mmmm;
@@ -52,7 +52,7 @@ describe("Regex", () => {
     it("failed match", () => {
         const regexp = new Regex(/[a-z]+/);
         const is = inputStateFromString("14 friday");
-        const m = regexp.matchPrefix(is, {});
+        const m = regexp.matchPrefix(is);
         assert(!isSuccessfulMatch(m));
     });
 
@@ -61,7 +61,7 @@ describe("Regex", () => {
         const regexp = new Regex(/[a-z]+/);
         const is = inputStateFromString("**friday 14");
         const withSkip = new Break(regexp, true);
-        const m = withSkip.matchPrefix(is, {});
+        const m = withSkip.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        const match = m as any as PatternMatch;

--- a/test/RegexTest.ts
+++ b/test/RegexTest.ts
@@ -1,7 +1,8 @@
 import { inputStateFromString } from "../src/internal/InputStateFactory";
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
 
 import { Microgrammar } from "../src/Microgrammar";
-import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
+import {  PatternMatch } from "../src/PatternMatch";
 import { Regex } from "../src/Primitives";
 
 import * as assert from "power-assert";
@@ -13,20 +14,30 @@ describe("Regex", () => {
         const regexp = new Regex(/[a-z]+/);
         const is = inputStateFromString("friday 14");
         const m = regexp.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        const match = m as PatternMatch;
-        assert(match.$matched === "friday");
-        assert(m.$offset === 0);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       const match = mmmm;
+                       assert(match.$matched === "friday");
+                       assert(mmmm.$offset === 0);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
     it("match word letters using anchor that will be recognized", () => {
         const regexp = new Regex(/[a-z]+/);
         const is = inputStateFromString("friday 14");
         const m = regexp.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        const match = m as PatternMatch;
-        assert(match.$matched === "friday");
-        assert(m.$offset === 0);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       const match = mmmm;
+                       assert(match.$matched === "friday");
+                       assert(mmmm.$offset === 0);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("should add anchor if not present", () => {
         const regexp = new Regex(/[a-z]+/);
@@ -42,7 +53,7 @@ describe("Regex", () => {
         const regexp = new Regex(/[a-z]+/);
         const is = inputStateFromString("14 friday");
         const m = regexp.matchPrefix(is, {});
-        assert(!isPatternMatch(m));
+        assert(!isSuccessfulMatch(m));
     });
 
     // Demonstrate how to achieve old style skipping behavior
@@ -51,12 +62,17 @@ describe("Regex", () => {
         const is = inputStateFromString("**friday 14");
         const withSkip = new Break(regexp, true);
         const m = withSkip.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        const match = m as any as PatternMatch;
-        assert(match.$matched === "**friday");
-        assert(match.$offset === 2);
-        assert(match.$value === "friday");
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       const match = m as any as PatternMatch;
+                       assert(match.$matched === "**friday");
+                       assert(match.$offset === 2);
+                       assert(match.$value === "friday");
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("matches regex length 20", () => matchRegexOfLength(20));
 

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -3,8 +3,8 @@ import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
 import { Rep, Rep1, Rep1Sep, RepSep } from "../src/Rep";
 import { LEGAL_VALUE } from "./MavenGrammars";
 
-import { Alt, Opt } from "../build/src/Ops";
 import { Microgrammar } from "../src/Microgrammar";
+import { Alt, Opt } from "../src/Ops";
 import { RealWorldPom } from "./Fixtures";
 
 import * as assert from "power-assert";

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -1,8 +1,13 @@
-import { expect } from "chai";
 import { inputStateFromString } from "../src/internal/InputStateFactory";
 import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
 import { Rep, Rep1, Rep1Sep, RepSep } from "../src/Rep";
 import { LEGAL_VALUE } from "./MavenGrammars";
+
+import { Alt, Opt } from "../build/src/Ops";
+import { Microgrammar } from "../src/Microgrammar";
+import { RealWorldPom } from "./Fixtures";
+
+import * as assert from "power-assert";
 
 describe("Rep", () => {
 
@@ -10,7 +15,7 @@ describe("Rep", () => {
         const rep = new Rep("A");
         const is = inputStateFromString("friday 14");
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
+        assert(isPatternMatch(m));
         // expect(is.peek(2)).to.equal(m.$resultingInputState.peek(2));
     });
 
@@ -18,21 +23,21 @@ describe("Rep", () => {
         const rep = new Rep1("A");
         const is = inputStateFromString("friday 14");
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(false);
+        assert(!isPatternMatch(m));
     });
 
     it("should match when matcher matches once", () => {
         const rep = new Rep("A");
         const is = inputStateFromString("And there was light!");
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
+        assert(isPatternMatch(m));
     });
 
     it("repsep should match when matcher matches once", () => {
         const rep = new RepSep("A", "abcd");
         const is = inputStateFromString("And there was light!");
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
+        assert(isPatternMatch(m));
     });
 
     it("rep matches several times", () => {
@@ -41,8 +46,8 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal(toMatch);
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === toMatch);
     });
 
     it("rep does not match several times when not ignoring whitespace", () => {
@@ -51,8 +56,8 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal("And");
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === "And");
     });
 
     it("can extract data after rep matches several times", () => {
@@ -61,7 +66,7 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {}) as PatternMatch;
-        expect(m.$value.length).to.equal(4);
+        assert(m.$value.length === 4);
     });
 
     it("repsep matches several times", () => {
@@ -70,8 +75,8 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal(toMatch);
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === toMatch);
     });
 
     it("rep1sep matches several times", () => {
@@ -80,8 +85,8 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal(toMatch);
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === toMatch);
     });
 
     it("rep1sep matches once", () => {
@@ -90,7 +95,7 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
+        assert(isPatternMatch(m));
     });
 
     it("rep1sep does not match zero times", () => {
@@ -99,7 +104,7 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(false);
+        assert(!isPatternMatch(m));
     });
 
     it("Maven property", () => {
@@ -111,8 +116,34 @@ describe("Rep", () => {
         `;
         const is = inputStateFromString(toMatch);
         const m = rep.matchPrefix(is, {}) as PatternMatch;
-        expect(isPatternMatch(m)).to.equal(true);
-        expect(m.$value.length).to.equal(3);
+        assert(isPatternMatch(m));
+        assert(m.$value.length === 3);
+    });
+
+    it.skip("should not infinite loop", () => {
+        const mgDependency = Microgrammar.fromDefinitions({
+            _dependencyTag: "<dependency>",
+            gav: new Rep(new Alt(
+                {
+                    _groupIdOpeningTag: "<groupId>",
+                    groupId: "com.krakow",
+                    _groupIdClosingTag: "</groupId>",
+                },
+                {
+                    _artifactIdOpeningTag: "<artifactId>",
+                    artifactId: "lib1",
+                    _artifactIdClosingtag: "</artifactId>",
+                },
+                new Opt({
+                    _versionOpeningTag: "<version>",
+                    version: "0.1.1",
+                    _versionClosingtag: "</version>",
+                }),
+            )),
+            _close: "</dependency>",
+        });
+        const m = mgDependency.firstMatch(RealWorldPom);
+        assert(m);
     });
 
 });

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -1,5 +1,6 @@
 import { inputStateFromString } from "../src/internal/InputStateFactory";
-import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
+import {  PatternMatch } from "../src/PatternMatch";
 import { Rep, Rep1, Rep1Sep, RepSep } from "../src/Rep";
 import { LEGAL_VALUE } from "./MavenGrammars";
 
@@ -15,30 +16,45 @@ describe("Rep", () => {
         const rep = new Rep("A");
         const is = inputStateFromString("friday 14");
         const m = rep.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        // expect(is.peek(2)).to.equal(m.$resultingInputState.peek(2));
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       // expect(is.peek(2)).to.equal(mmmm.$resultingInputState.peek(2));
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("rep(1) should NOT match 0 when matcher doesn't match", () => {
         const rep = new Rep1("A");
         const is = inputStateFromString("friday 14");
         const m = rep.matchPrefix(is, {});
-        assert(!isPatternMatch(m));
+        assert(!isSuccessfulMatch(m));
     });
 
     it("should match when matcher matches once", () => {
         const rep = new Rep("A");
         const is = inputStateFromString("And there was light!");
         const m = rep.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("repsep should match when matcher matches once", () => {
         const rep = new RepSep("A", "abcd");
         const is = inputStateFromString("And there was light!");
         const m = rep.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("rep matches several times", () => {
         const rep = new Rep(/[a-zA-Z]+/);
@@ -46,9 +62,14 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === toMatch);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert((mmmm).$matched === toMatch);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("rep does not match several times when not ignoring whitespace", () => {
         const rep = new Rep(/[a-zA-Z]+/).withConfig({consumeWhiteSpaceBetweenTokens: false});
@@ -56,9 +77,14 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === "And");
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert((mmmm).$matched === "And");
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("can extract data after rep matches several times", () => {
         const rep = new Rep(/[a-zA-Z]+/);
@@ -75,9 +101,14 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === toMatch);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert((mmmm).$matched === toMatch);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("rep1sep matches several times", () => {
         const rep = new Rep1Sep(/[a-zA-Z]+/, ",");
@@ -85,9 +116,14 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === toMatch);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert((mmmm).$matched === toMatch);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("rep1sep matches once", () => {
         const rep = new Rep1Sep(/[a-zA-Z]+/, ",");
@@ -95,8 +131,13 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("rep1sep does not match zero times", () => {
         const rep = new Rep1Sep(/[a-zA-Z]+/, ",");
@@ -104,7 +145,7 @@ describe("Rep", () => {
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {});
-        assert(!isPatternMatch(m));
+        assert(!isSuccessfulMatch(m));
     });
 
     it("Maven property", () => {
@@ -116,9 +157,14 @@ describe("Rep", () => {
         `;
         const is = inputStateFromString(toMatch);
         const m = rep.matchPrefix(is, {}) as PatternMatch;
-        assert(isPatternMatch(m));
-        assert(m.$value.length === 3);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert(mmmm.$value.length === 3);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("should not infinite loop on rep of opt", () => {
         const mgDependency = Microgrammar.fromDefinitions({

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -41,7 +41,7 @@ describe("Rep", () => {
     });
 
     it("rep matches several times", () => {
-        const rep = new Rep(/^[a-zA-Z]+/);
+        const rep = new Rep(/[a-zA-Z]+/);
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
@@ -51,7 +51,7 @@ describe("Rep", () => {
     });
 
     it("rep does not match several times when not ignoring whitespace", () => {
-        const rep = new Rep(/^[a-zA-Z]+/).withConfig({consumeWhiteSpaceBetweenTokens: false});
+        const rep = new Rep(/[a-zA-Z]+/).withConfig({consumeWhiteSpaceBetweenTokens: false});
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
@@ -61,7 +61,7 @@ describe("Rep", () => {
     });
 
     it("can extract data after rep matches several times", () => {
-        const rep = new Rep(/^[a-zA-Z]+/);
+        const rep = new Rep(/[a-zA-Z]+/);
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
@@ -70,7 +70,7 @@ describe("Rep", () => {
     });
 
     it("repsep matches several times", () => {
-        const rep = new RepSep(/^[a-zA-Z]+/, ",");
+        const rep = new RepSep(/[a-zA-Z]+/, ",");
         const toMatch = "And,there,was,light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
@@ -80,7 +80,7 @@ describe("Rep", () => {
     });
 
     it("rep1sep matches several times", () => {
-        const rep = new Rep1Sep(/^[a-zA-Z]+/, ",");
+        const rep = new Rep1Sep(/[a-zA-Z]+/, ",");
         const toMatch = "And,there,was,light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
@@ -90,7 +90,7 @@ describe("Rep", () => {
     });
 
     it("rep1sep matches once", () => {
-        const rep = new Rep1Sep(/^[a-zA-Z]+/, ",");
+        const rep = new Rep1Sep(/[a-zA-Z]+/, ",");
         const toMatch = "And";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
@@ -99,7 +99,7 @@ describe("Rep", () => {
     });
 
     it("rep1sep does not match zero times", () => {
-        const rep = new Rep1Sep(/^[a-zA-Z]+/, ",");
+        const rep = new Rep1Sep(/[a-zA-Z]+/, ",");
         const toMatch = "16And";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
@@ -170,7 +170,7 @@ const property = {
     _gt: "<",
     name: LEGAL_VALUE,
     _close: ">",
-    value: /^[^<]+/,
+    value: /[^<]+/,
     _gt2: "</",
     _closing: LEGAL_VALUE,
     _done: ">",

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -51,7 +51,7 @@ describe("Rep", () => {
     });
 
     it("rep does not match several times when not ignoring whitespace", () => {
-        const rep = new Rep(/^[a-zA-Z]+/).withConfig({ consumeWhiteSpaceBetweenTokens: false });
+        const rep = new Rep(/^[a-zA-Z]+/).withConfig({consumeWhiteSpaceBetweenTokens: false});
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
@@ -120,7 +120,24 @@ describe("Rep", () => {
         assert(m.$value.length === 3);
     });
 
-    it.skip("should not infinite loop", () => {
+    it("should not infinite loop on rep of opt", () => {
+        const mgDependency = Microgrammar.fromDefinitions({
+            _dependencyTag: "<dependency>",
+            gav: new Rep(
+                new Opt({
+                    _versionOpeningTag: "<version>",
+                    version: "0.1.1",
+                    _versionClosingtag: "</version>",
+                }),
+            ),
+            _close: "</dependency>",
+        });
+        assert.throws(
+            () => mgDependency.firstMatch(RealWorldPom),
+            m => { assert(m.message.indexOf("empty string") !== -1); return true; });
+    });
+
+    it("should not infinite loop on rep of alt with opt", () => {
         const mgDependency = Microgrammar.fromDefinitions({
             _dependencyTag: "<dependency>",
             gav: new Rep(new Alt(
@@ -142,8 +159,9 @@ describe("Rep", () => {
             )),
             _close: "</dependency>",
         });
-        const m = mgDependency.firstMatch(RealWorldPom);
-        assert(m);
+        assert.throws(
+            () => mgDependency.firstMatch(RealWorldPom),
+            m => { assert(m.message.indexOf("empty string") !== -1); return true; });
     });
 
 });

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -15,7 +15,7 @@ describe("Rep", () => {
     it("rep(0) should match 0 when matcher doesn't match", () => {
         const rep = new Rep("A");
         const is = inputStateFromString("friday 14");
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        // expect(is.peek(2)).to.equal(mmmm.$resultingInputState.peek(2));
@@ -28,14 +28,14 @@ describe("Rep", () => {
     it("rep(1) should NOT match 0 when matcher doesn't match", () => {
         const rep = new Rep1("A");
         const is = inputStateFromString("friday 14");
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         assert(!isSuccessfulMatch(m));
     });
 
     it("should match when matcher matches once", () => {
         const rep = new Rep("A");
         const is = inputStateFromString("And there was light!");
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -47,7 +47,7 @@ describe("Rep", () => {
     it("repsep should match when matcher matches once", () => {
         const rep = new RepSep("A", "abcd");
         const is = inputStateFromString("And there was light!");
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -61,7 +61,7 @@ describe("Rep", () => {
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert((mmmm).$matched === toMatch);
@@ -76,7 +76,7 @@ describe("Rep", () => {
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert((mmmm).$matched === "And");
@@ -91,7 +91,7 @@ describe("Rep", () => {
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is, {}) as PatternMatch;
+        const m = rep.matchPrefix(is) as PatternMatch;
         assert(m.$value.length === 4);
     });
 
@@ -100,7 +100,7 @@ describe("Rep", () => {
         const toMatch = "And,there,was,light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert((mmmm).$matched === toMatch);
@@ -115,7 +115,7 @@ describe("Rep", () => {
         const toMatch = "And,there,was,light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert((mmmm).$matched === toMatch);
@@ -130,7 +130,7 @@ describe("Rep", () => {
         const toMatch = "And";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -144,7 +144,7 @@ describe("Rep", () => {
         const toMatch = "16And";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is, {});
+        const m = rep.matchPrefix(is);
         assert(!isSuccessfulMatch(m));
     });
 
@@ -156,7 +156,7 @@ describe("Rep", () => {
 	</properties>
         `;
         const is = inputStateFromString(toMatch);
-        const m = rep.matchPrefix(is, {}) as PatternMatch;
+        const m = rep.matchPrefix(is) as PatternMatch;
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$value.length === 3);

--- a/test/StringGrammarTest.ts
+++ b/test/StringGrammarTest.ts
@@ -11,7 +11,10 @@ import {isSuccessfulMatch} from "../src/MatchPrefixResult";
 describe("StringGrammarTest", () => {
 
     it("broken in concat", () => {
-        const strings = Microgrammar.fromDefinitions<any>({theString: new Alt(StringGrammar.stringGrammar, "la")}).findMatches('"    winter is coming " la la la');
+        const strings =
+            Microgrammar.fromDefinitions<any>(
+                {theString: new Alt(StringGrammar.stringGrammar, "la")}).
+            findMatches('"    winter is coming " la la la');
         const match = strings[0];
         assert(isPatternMatch(match));
 
@@ -25,9 +28,10 @@ describe("StringGrammarTest", () => {
     });
 
     it("not broken without concat", () => {
-        const result = new Alt(StringGrammar.stringGrammar, "la").matchPrefix(inputStateFromString('"    winter is coming " la la la'));
+        const result = new Alt(StringGrammar.stringGrammar, "la").
+        matchPrefix(inputStateFromString('"    winter is coming " la la la'));
         if (isSuccessfulMatch(result)) {
-            const match = result.match
+            const match = result.match;
             if (isPatternMatch(match)) {
                 assert(isPatternMatch(match));
                 assert(match.$matched === '"    winter is coming "');
@@ -45,7 +49,8 @@ class StringGrammar {
     public static readonly stringTextPattern = new Rep(new Alt("\\\"", /^[^"]/))
         .withConfig({consumeWhiteSpaceBetweenTokens: false});
 
-    public static readonly stringGrammar: Microgrammar<any> = Microgrammar.fromDefinitions<any>({
+    public static readonly stringGrammar: Microgrammar<any> =
+        Microgrammar.fromDefinitions<any>({
         _p1: '"',
         charArray: StringGrammar.stringTextPattern,
         _p2: '"',

--- a/test/StringGrammarTest.ts
+++ b/test/StringGrammarTest.ts
@@ -1,0 +1,56 @@
+import "mocha";
+import {inputStateFromString} from "../src/internal/InputStateFactory";
+import {Microgrammar} from "../src/Microgrammar";
+import {Alt} from "../src/Ops";
+import {isPatternMatch} from "../src/PatternMatch";
+import {Rep} from "../src/Rep";
+
+import * as assert from "power-assert";
+import {isSuccessfulMatch} from "../src/MatchPrefixResult";
+
+describe("StringGrammarTest", () => {
+
+    it("broken in concat", () => {
+        const strings = Microgrammar.fromDefinitions<any>({theString: new Alt(StringGrammar.stringGrammar, "la")}).findMatches('"    winter is coming " la la la');
+        const match = strings[0];
+        assert(isPatternMatch(match));
+
+        // for (const k in match) {
+        //     console.log(`[${k}]=${match[k]}`);
+        // }
+
+        console.log("The string is " + match.theString);
+        assert(match.$matched === '"    winter is coming "');
+        assert(match.theString.text, "    winter is coming");
+    });
+
+    it("not broken without concat", () => {
+        const result = new Alt(StringGrammar.stringGrammar, "la").matchPrefix(inputStateFromString('"    winter is coming " la la la'));
+        if (isSuccessfulMatch(result)) {
+            const match = result.match
+            if (isPatternMatch(match)) {
+                assert(isPatternMatch(match));
+                assert(match.$matched === '"    winter is coming "');
+            }
+            assert((match as any).text, "    winter is coming");
+        } else {
+            assert.fail("did not match");
+        }
+    });
+
+});
+
+class StringGrammar {
+
+    public static readonly stringTextPattern = new Rep(new Alt("\\\"", /^[^"]/))
+        .withConfig({consumeWhiteSpaceBetweenTokens: false});
+
+    public static readonly stringGrammar: Microgrammar<any> = Microgrammar.fromDefinitions<any>({
+        _p1: '"',
+        charArray: StringGrammar.stringTextPattern,
+        _p2: '"',
+        text: ctx => ctx.charArray.join(""),
+        $id: "stringText",
+    });
+
+}

--- a/test/StringificationTest.ts
+++ b/test/StringificationTest.ts
@@ -34,7 +34,6 @@ describe("stringification", () => {
         });
         const result = mg.findMatches(content);
 
-        console.log("Result is " + JSON.stringify(result));
         assert(result.length === 1);
 
         const stringified = JSON.stringify(result[0]);

--- a/test/WhenTest.ts
+++ b/test/WhenTest.ts
@@ -1,8 +1,11 @@
-import { expect } from "chai";
-import { inputStateFromString } from "../src/internal/InputStateFactory";
-import { when } from "../src/Ops";
-import { isPatternMatch } from "../src/PatternMatch";
-import { Literal } from "../src/Primitives";
+import {expect} from "chai";
+import {inputStateFromString} from "../src/internal/InputStateFactory";
+import {isSuccessfulMatch} from "../src/MatchPrefixResult";
+import {when} from "../src/Ops";
+
+import {Literal} from "../src/Primitives";
+
+import * as assert from "power-assert";
 
 describe("When", () => {
 
@@ -17,7 +20,12 @@ describe("When", () => {
             throw new Error("Error: matcher.matchPrefix returned by when is undefined");
         }
         const m = matcher.matchPrefix(is);
-        expect(isPatternMatch(m)).to.equal(true);
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("when false should not match", () => {
@@ -25,7 +33,7 @@ describe("When", () => {
         const is = inputStateFromString("foo bar");
         const matcher = when(primitive, pm => false);
         const m = matcher.matchPrefix(is);
-        expect(isPatternMatch(m)).to.equal(false);
+        expect(isSuccessfulMatch(m)).to.equal(false);
     });
 
     it("ability to veto content", () => {
@@ -33,7 +41,7 @@ describe("When", () => {
         const is = inputStateFromString("foo bar");
         const hatesFoo = when(primitive, pm => pm.$matched.indexOf("foo") === -1);
         const m = hatesFoo.matchPrefix(is);
-        expect(isPatternMatch(m)).to.equal(false);
+        expect(isSuccessfulMatch(m)).to.equal(false);
     });
 
     it("ability to veto content: not vetoed", () => {
@@ -41,7 +49,12 @@ describe("When", () => {
         const is = inputStateFromString("bar and this is a load of other stuff");
         const hatesFoo = when(primitive, pm => pm.$matched.indexOf("foo") === -1);
         const m = hatesFoo.matchPrefix(is);
-        expect(isPatternMatch(m)).to.equal(true);
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("ability to require content: match", () => {
@@ -49,7 +62,12 @@ describe("When", () => {
         const is = inputStateFromString("foo bar");
         const requiresFoo = when(primitive, pm => pm.$matched.indexOf("foo") !== -1);
         const m = requiresFoo.matchPrefix(is);
-        expect(isPatternMatch(m)).to.equal(true);
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("ability to require content: no match", () => {
@@ -57,7 +75,7 @@ describe("When", () => {
         const is = inputStateFromString("bar");
         const requiresFoo = when(primitive, pm => pm.$matched.indexOf("foo") !== -1);
         const m = requiresFoo.matchPrefix(is);
-        expect(isPatternMatch(m)).to.equal(false);
+        expect(isSuccessfulMatch(m)).to.equal(false);
     });
 
     it("preserves properties", () => {

--- a/test/WhenTest.ts
+++ b/test/WhenTest.ts
@@ -37,7 +37,7 @@ describe("When", () => {
     });
 
     it("ability to veto content: not vetoed", () => {
-        const primitive = new RegExp(/^[a-z]+/);
+        const primitive = new RegExp(/[a-z]+/);
         const is = inputStateFromString("bar and this is a load of other stuff");
         const hatesFoo = when(primitive, pm => pm.$matched.indexOf("foo") === -1);
         const m = hatesFoo.matchPrefix(is);

--- a/test/fromString/ElementsDefaultToNonGreedyAnyTest.ts
+++ b/test/fromString/ElementsDefaultToNonGreedyAnyTest.ts
@@ -1,3 +1,4 @@
+import {isSuccessfulMatch} from "../../src/MatchPrefixResult";
 import assert = require("power-assert");
 import {Microgrammar} from "../../src/Microgrammar";
 import {isPatternMatch} from "../../src/PatternMatch";
@@ -8,17 +9,26 @@ describe("Elements default to non-greedy any", () => {
         const content = "->banana<- ";
         const mg = Microgrammar.fromString("->${fruit}<-");
         const result: any = mg.exactMatch(content);
-        assert(isPatternMatch(result));
-        assert(result.fruit === "banana");
+        if (isPatternMatch(result)) {
+            const mmmm = result as any;
+            assert(mmmm.fruit === "banana");
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("multiple undefined elements are fine if they're separated by a literal", () => {
         const content = "preamble content ->banana<-juice! and more...";
         const mg = Microgrammar.fromString<{ fruit: string, drink: string }>("->${fruit}<-${drink}!");
         const result: any = mg.firstMatch(content);
-        assert(isPatternMatch(result));
-        assert(result.fruit === "banana");
-        assert(result.drink === "juice");
+        if (isPatternMatch(result)) {
+            const mmmm = result as any;
+            assert(mmmm.fruit === "banana");
+            assert(mmmm.drink === "juice");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("multiple undefined elements are fine if they're separated by a defined element", () => {
@@ -34,17 +44,27 @@ describe("Elements default to non-greedy any", () => {
         const content = "->   banana   <- ";
         const mg = Microgrammar.fromString("-> ${fruit} <-");
         const result: any = mg.exactMatch(content);
-        assert(isPatternMatch(result));
-        assert(result.fruit.trim() === "banana");
+        if (isPatternMatch(result)) {
+            const mmmm = result as any;
+            assert(mmmm.fruit.trim() === "banana");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it.skip("trims whitespace from the captured text",
         () => {
-        const content = "->   banana   <- ";
-        const mg = Microgrammar.fromString("-> ${fruit} <-");
-        const result: any = mg.exactMatch(content);
-        assert(isPatternMatch(result));
-        assert(result.fruit === "banana");
-    });
+            const content = "->   banana   <- ";
+            const mg = Microgrammar.fromString("-> ${fruit} <-");
+            const result: any = mg.exactMatch(content);
+            if (isPatternMatch(result)) {
+                const mmmm = result as any;
+                assert(mmmm.fruit === "banana");
+
+            } else {
+                assert.fail("Didn't match");
+            }
+        });
 
 });

--- a/test/fromString/MicrogrammarFromStringTest.ts
+++ b/test/fromString/MicrogrammarFromStringTest.ts
@@ -1,13 +1,15 @@
 import { expect } from "chai";
 import { Microgrammar } from "../../src/Microgrammar";
 import { Opt } from "../../src/Ops";
-import { PatternMatch } from "../../src/PatternMatch";
+import {isPatternMatch, PatternMatch} from "../../src/PatternMatch";
 import { RepSep } from "../../src/Rep";
 import { RealWorldPom } from "../Fixtures";
 import {
     ALL_PLUGIN_GRAMMAR, ARTIFACT_VERSION_GRAMMAR, LEGAL_VALUE, PLUGIN_GRAMMAR,
     VersionedArtifact,
 } from "../MavenGrammars";
+
+import * as assert from "power-assert";
 
 describe("MicrogrammarFromString", () => {
 
@@ -171,15 +173,8 @@ describe("MicrogrammarFromString", () => {
         // console.log("Result is " + JSON.stringify(result));
         expect(result.length).to.equal(1);
         const r0 = result[0] as any;
-        expect(result[0].$matched).to.equal(content);
         expect(r0.first.name).to.equal("first");
-        expect(r0.first.$match.$matched).to.equal("<first>");
         expect(r0.second.name).to.equal("second");
-        // Now access match for the name
-        const nameMatch = r0.second.name$match as PatternMatch;
-        expect(nameMatch.$value).to.equal("second");
-        expect(nameMatch.$matched).to.equal(nameMatch.$value);
-        expect(nameMatch.$offset).to.equal("<first><".length);
     });
 
     it("1 XML elements via nested microgrammar with optional not present", () => {
@@ -194,11 +189,11 @@ describe("MicrogrammarFromString", () => {
             second: new Opt(element),
         });
         const result = mg.findMatches(content);
-        // console.log("Result is " + JSON.stringify(result));
         expect(result.length).to.equal(1);
         const r0 = result[0] as any;
+        assert(isPatternMatch(r0));
         expect(r0.$matched).to.equal(content);
-        expect(r0.first.$match.$matched).to.equal("<first>");
+        expect(r0.first.$matched).to.equal("<first>");
         expect(r0.second).to.equal(undefined);
     });
 
@@ -218,8 +213,6 @@ describe("MicrogrammarFromString", () => {
         // console.log("Result is " + JSON.stringify(result));
         expect(result.length).to.equal(1);
         const r0 = result[0] as any;
-        expect(r0.$matched).to.equal(content);
-        expect(r0.first.$match.$matched).to.equal("<first>");
         expect(r0.first.name).to.equal("first");
         expect(r0.second.name).to.equal("second");
     });

--- a/test/fromString/MicrogrammarFromStringTest.ts
+++ b/test/fromString/MicrogrammarFromStringTest.ts
@@ -142,7 +142,7 @@ describe("MicrogrammarFromStringTest", () => {
             name: string;
         }
         const mg = Microgrammar.fromString<Named>("${name}", {
-            name: /^[A-Z][a-z]+/,
+            name: /[A-Z][a-z]+/,
         });
         const result = mg.findMatches("Greg Tony");
         expect(result.length).to.equal(2);

--- a/test/fromString/SpecGrammarTest.ts
+++ b/test/fromString/SpecGrammarTest.ts
@@ -1,7 +1,7 @@
 import assert = require("power-assert");
 import { exactMatch } from "../../src/internal/ExactMatch";
 import { MicrogrammarSpec, specGrammar } from "../../src/internal/SpecGrammar";
-import { isPatternMatch } from "../../src/PatternMatch";
+import {isPatternMatch} from "../../src/PatternMatch";
 
 describe("SpecGrammar", () => {
 

--- a/test/fromString/SpecGrammarTest.ts
+++ b/test/fromString/SpecGrammarTest.ts
@@ -10,16 +10,13 @@ describe("SpecGrammar", () => {
         const specMatch = exactMatch<MicrogrammarSpec>(specGrammar, microgrammarSpecString);
         if (isPatternMatch(specMatch)) {
             assert(specMatch.these.length === 1);
-            const json = JSON.stringify(specMatch.matchedStructure());
-            assert(json ===
-                JSON.stringify({
+            assert.deepEqual(specMatch.matchedStructure(),
+               {
                     these: [{
-                        elementName: "fruit", // TODO: this doesn't belong here. Is it a bug in concat?
                         literal: "->", element: {elementName: "fruit"},
                     }]
                     , trailing: "<-",
-                }),
-                json);
+                });
         } else {
             assert.fail();
         }

--- a/test/integration/RealWorldTest.ts
+++ b/test/integration/RealWorldTest.ts
@@ -83,8 +83,8 @@ describe("Real world usage", () => {
 
 class MethodSignatureGrammar {
 
-    public readonly javaIdentifierPattern = /^[a-zA-Z_$][a-zA-Z0-9_$]*/;
-    public readonly javaTypePattern = /^[a-zA-Z_$\.][a-zA-Z0-9_$\.]*/;
+    public readonly javaIdentifierPattern = /[a-zA-Z_$][a-zA-Z0-9_$]*/;
+    public readonly javaTypePattern = /[a-zA-Z_$\.][a-zA-Z0-9_$\.]*/;
 
     public javaAnnotationGrammar = new AnnotationGrammar();
 
@@ -112,8 +112,8 @@ class MethodSignatureGrammar {
 
 export class AnnotationGrammar {
 
-    public readonly javaIdentifierPattern = /^[a-zA-Z_$][a-zA-Z0-9_$]*/;
-    public readonly javaTypePattern = /^[a-zA-Z_$\.][a-zA-Z0-9_$\.]*/;
+    public readonly javaIdentifierPattern = /[a-zA-Z_$][a-zA-Z0-9_$]*/;
+    public readonly javaTypePattern = /[a-zA-Z_$\.][a-zA-Z0-9_$\.]*/;
 
     public readonly javaType = Microgrammar.fromDefinitions({
         text: this.javaTypePattern,

--- a/test/integration/RealWorldTest2.ts
+++ b/test/integration/RealWorldTest2.ts
@@ -1,5 +1,6 @@
 import { JavaBlock, JavaParenthesizedExpression } from "../../src/matchers/java/JavaBody";
-import { isPatternMatch, PatternMatch } from "../../src/PatternMatch";
+import { isSuccessfulMatch } from "../../src/MatchPrefixResult";
+import {  PatternMatch } from "../../src/PatternMatch";
 
 import { Microgrammar } from "../../src/Microgrammar";
 import { Opt } from "../../src/Ops";
@@ -39,9 +40,14 @@ describe("GrammarWithOnlyARep", () => {
         const rep = new Rep(AnyAnnotation);
         const src = `@ChangeControlled @Donkey("24", name = "Eeyore") public void magic() {}`;
         const match = rep.matchPrefix(inputStateFromString(src), {}) as PatternMatch;
-        assert(isPatternMatch(match));
-        assert(match.$matched.trim() === `@ChangeControlled @Donkey("24", name = "Eeyore")`);
-    });
+        if (isSuccessfulMatch(match)) {
+                       const mmmm = match.match as any;
+                       assert(mmmm.$matched.trim() === `@ChangeControlled @Donkey("24", name = "Eeyore")`);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("match valid annotations with trailing junk", () => {
         const src = `@ChangeControlled @Donkey("24", name = "Eeyore")

--- a/test/integration/RealWorldTest2.ts
+++ b/test/integration/RealWorldTest2.ts
@@ -39,7 +39,7 @@ describe("GrammarWithOnlyARep", () => {
     it("can handle rep", () => {
         const rep = new Rep(AnyAnnotation);
         const src = `@ChangeControlled @Donkey("24", name = "Eeyore") public void magic() {}`;
-        const match = rep.matchPrefix(inputStateFromString(src), {}) as PatternMatch;
+        const match = rep.matchPrefix(inputStateFromString(src)) as PatternMatch;
         if (isSuccessfulMatch(match)) {
                        const mmmm = match.match as any;
                        assert(mmmm.$matched.trim() === `@ChangeControlled @Donkey("24", name = "Eeyore")`);

--- a/test/integration/RealWorldTest2.ts
+++ b/test/integration/RealWorldTest2.ts
@@ -64,7 +64,7 @@ describe("GrammarWithOnlyARep", () => {
 
 });
 
-export const JAVA_IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*/;
+export const JAVA_IDENTIFIER = /[a-zA-Z_$][a-zA-Z0-9_$]*/;
 
 export const AnyAnnotation = Microgrammar.fromDefinitions<RawAnnotation>({
     _at: "@",

--- a/test/internal/MicrogrammarUpdateTest.ts
+++ b/test/internal/MicrogrammarUpdateTest.ts
@@ -29,8 +29,8 @@ describe("MicrogrammarUpdateTest", () => {
         updater.second = "<newSecond>";
         assert(updater.newContent() === "<first><newSecond>");
         const cs = new ChangeSet(content);
-        assert(result[0].second.name$match);
-        cs.change(result[0].second.name$match, "newSecond");
+        assert(result[0].second.$value.name$match);
+        cs.change(result[0].second.$value.name$match, "newSecond");
         assert(cs.updated() === "<first><newSecond>");
     });
 
@@ -45,6 +45,7 @@ describe("MicrogrammarUpdateTest", () => {
             },
         });
         const line = "Jenny 46 Coonamble, Mosman";
+
         const result = person.findMatches(line) as any;
         const updater = Microgrammar.updatableMatch(result[0], line);
         updater.address.number = 45;

--- a/test/internal/MicrogrammarUpdateTest.ts
+++ b/test/internal/MicrogrammarUpdateTest.ts
@@ -29,8 +29,8 @@ describe("MicrogrammarUpdateTest", () => {
         updater.second = "<newSecond>";
         assert(updater.newContent() === "<first><newSecond>");
         const cs = new ChangeSet(content);
-        assert(result[0].second.$value.name$match);
-        cs.change(result[0].second.$value.name$match, "newSecond");
+        assert(result[0].second.$valueMatches.name);
+        cs.change(result[0].second.$valueMatches.name, "newSecond");
         assert(cs.updated() === "<first><newSecond>");
     });
 

--- a/test/internal/MicrogrammarUpdateTest.ts
+++ b/test/internal/MicrogrammarUpdateTest.ts
@@ -1,12 +1,12 @@
-import { ChangeSet } from "../../src/internal/ChangeSet";
-import { Microgrammar } from "../../src/Microgrammar";
-import { Opt } from "../../src/Ops";
+import {ChangeSet} from "../../src/internal/ChangeSet";
+import {isSuccessfulMatch} from "../../src/MatchPrefixResult";
+import {Microgrammar} from "../../src/Microgrammar";
+import {Opt} from "../../src/Ops";
 
 import * as assert from "power-assert";
 
-import { isPatternMatch } from "../../src/PatternMatch";
-import { Integer } from "../../src/Primitives";
-import { RepSep } from "../../src/Rep";
+import {Integer} from "../../src/Primitives";
+import {RepSep} from "../../src/Rep";
 
 describe("MicrogrammarUpdateTest", () => {
 
@@ -176,14 +176,18 @@ describe("MicrogrammarUpdateTest", () => {
         });
 
         const match: any = mg.firstMatch(input);
-        assert(isPatternMatch(match));
-        assert(match.listItems.commaSeparated[0] === "carrots");
+        if (isSuccessfulMatch(match)) {
+            const mmmm = match.match as any;
+            assert(mmmm.listItems.commaSeparated[0] === "carrots");
 
-        // how about we also accept a microgrammar as the first arg? ... and all firstMatch on it?
-        const updater: any = Microgrammar.updatableMatch(match, input);
-        updater.listItems.commaSeparated[0] = "garbage";
-        assert(updater.newContent() === "I love garbage, apples, lizards, bananas");
+            // how about we also accept a microgrammar as the first arg? ... and all firstMatch on it?
+            const updater: any = Microgrammar.updatableMatch(mmmm, input);
+            updater.listItems.commaSeparated[0] = "garbage";
+            assert(updater.newContent() === "I love garbage, apples, lizards, bananas");
 
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
 });

--- a/test/matchers/ConcatTest.ts
+++ b/test/matchers/ConcatTest.ts
@@ -1,10 +1,10 @@
 import { expect } from "chai";
-import { Concat } from "../src/Concat";
-import { inputStateFromString } from "../src/internal/InputStateFactory";
-import { Term } from "../src/Matchers";
-import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
-import { Integer } from "../src/Primitives";
-import { Rep1Sep, RepSep } from "../src/Rep";
+import { inputStateFromString } from "../../src/internal/InputStateFactory";
+import { Term } from "../../src/Matchers";
+import { Concat } from "../../src/matchers/Concat";
+import { isPatternMatch, PatternMatch } from "../../src/PatternMatch";
+import { Integer } from "../../src/Primitives";
+import { Rep1Sep, RepSep } from "../../src/Rep";
 
 import * as assert from "power-assert";
 

--- a/test/matchers/ConcatTest.ts
+++ b/test/matchers/ConcatTest.ts
@@ -16,7 +16,7 @@ describe("Concat", () => {
             name: "foo",
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {});
+        const result = mg.matchPrefix(is);
         if (isSuccessfulMatch(result)) {
             expect((result.match as any).name).to.equal("foo");
             assert(result.$matched === "foo");
@@ -32,7 +32,7 @@ describe("Concat", () => {
             num: /[1-9][0-9]*/,
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
+        const result = mg.matchPrefix(is) as any;
         if (isSuccessfulMatch(result)) {
             const mmm = result.match as any;
             assert(mmm.$matched === content);
@@ -46,7 +46,7 @@ describe("Concat", () => {
             num: Integer,
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
+        const result = mg.matchPrefix(is) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             // expect(mmmm.$matched).to.equal(content);
@@ -67,7 +67,7 @@ describe("Concat", () => {
             num: Integer,
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
+        const result = mg.matchPrefix(is) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             expect(mmmm.$matched).to.equal(content);
@@ -86,7 +86,7 @@ describe("Concat", () => {
             days: Integer,
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
+        const result = mg.matchPrefix(is) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             expect(mmmm.$matched).to.equal(content);
@@ -108,7 +108,7 @@ describe("Concat", () => {
         });
         const content = "Lizzy+Katrina";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
+        const result = mg.matchPrefix(is) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.name === "Lizzy");
@@ -129,7 +129,7 @@ describe("Concat", () => {
         });
         const content = "Lizzy+Katrina,Terri";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
+        const result = mg.matchPrefix(is) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.names[0], "Lizzy");
@@ -152,7 +152,7 @@ describe("Concat", () => {
         });
         const content = "Jardine vs Bradman,Woodfull";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
+        const result = mg.matchPrefix(is) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.gentlemen.names[0], "Jardine");
@@ -172,7 +172,7 @@ describe("Concat", () => {
         });
         const content = "Jardine vs Bradman,Woodfull";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
+        const result = mg.matchPrefix(is) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.gentlemen[0], "Jardine");
@@ -200,7 +200,7 @@ describe("Concat", () => {
         });
         const content = "Jardine(bat),Wyatt(bat) vs Bradman(bat,bowl),Woodfull(bat,keep)";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
+        const result = mg.matchPrefix(is) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.gentlemen.names[0].name, "Jardine");
@@ -224,7 +224,7 @@ describe("Concat", () => {
             hobbies: new RepSep(/[a-z]+/, ","),
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as PatternMatch;
+        const result = mg.matchPrefix(is) as PatternMatch;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             const r = mmmm as any;

--- a/test/matchers/ConcatTest.ts
+++ b/test/matchers/ConcatTest.ts
@@ -1,9 +1,10 @@
-import { expect } from "chai";
-import { inputStateFromString } from "../../src/internal/InputStateFactory";
-import { Concat } from "../../src/matchers/Concat";
-import { isPatternMatch, PatternMatch } from "../../src/PatternMatch";
-import { Integer } from "../../src/Primitives";
-import { Rep1Sep, RepSep } from "../../src/Rep";
+import {expect} from "chai";
+import {inputStateFromString} from "../../src/internal/InputStateFactory";
+import {Concat} from "../../src/matchers/Concat";
+import {isSuccessfulMatch} from "../../src/MatchPrefixResult";
+import {PatternMatch} from "../../src/PatternMatch";
+import {Integer} from "../../src/Primitives";
+import {Rep1Sep, RepSep} from "../../src/Rep";
 
 import * as assert from "power-assert";
 
@@ -15,10 +16,13 @@ describe("Concat", () => {
             name: "foo",
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is, {}) as any;
-        expect(isPatternMatch(result)).to.equal(true);
-        expect(result.$matched).to.equal("foo");
-        expect(result.name).to.equal("foo");
+        const result = mg.matchPrefix(is, {});
+        if (isSuccessfulMatch(result)) {
+            expect((result.match as any).name).to.equal("foo");
+            assert(result.$matched === "foo");
+        } else {
+            assert.fail("Did not match");
+        }
     });
 
     it("single digit with regex", () => {
@@ -29,9 +33,11 @@ describe("Concat", () => {
         });
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        assert(isPatternMatch(result));
-        assert(result.$matched === content);
-        assert(result.num === "2");
+        if (isSuccessfulMatch(result)) {
+            const mmm = result.match as any;
+            assert(mmm.$matched === content);
+            assert(mmm.num === "2");
+        }
     });
 
     it("integer with single digit", () => {
@@ -41,13 +47,18 @@ describe("Concat", () => {
         });
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        expect(isPatternMatch(result)).to.equal(true);
-        // expect(result.$matched).to.equal(content);
-        // expect(result.$matchers.length).to.equal(1);
-        // console.log(JSON.stringify(result.$matchers[0]))
-        // expect(result.$matchers[0].$value).to.equal(2);
-        // expect(result.$value).to.equal(2);
-        expect(result.num).to.equal(2);
+        if (isSuccessfulMatch(result)) {
+            const mmmm = result.match as any;
+            // expect(mmmm.$matched).to.equal(content);
+            // expect(mmmm.$matchers.length).to.equal(1);
+            // console.log(JSON.stringify(mmmm.$matchers[0]))
+            // expect(mmmm.$matchers[0].$value).to.equal(2);
+            // expect(mmmm.$value).to.equal(2);
+            expect(mmmm.num).to.equal(2);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("integer with multiple digits", () => {
@@ -57,9 +68,14 @@ describe("Concat", () => {
         });
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        expect(isPatternMatch(result)).to.equal(true);
-        expect(result.$matched).to.equal(content);
-        expect(result.num).to.equal(24);
+        if (isSuccessfulMatch(result)) {
+            const mmmm = result.match as any;
+            expect(mmmm.$matched).to.equal(content);
+            expect(mmmm.num).to.equal(24);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("integers", () => {
@@ -71,10 +87,15 @@ describe("Concat", () => {
         });
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        expect(isPatternMatch(result)).to.equal(true);
-        expect(result.$matched).to.equal(content);
-        expect(result.hours).to.equal(24);
-        expect(result.days).to.equal(7);
+        if (isSuccessfulMatch(result)) {
+            const mmmm = result.match as any;
+            expect(mmmm.$matched).to.equal(content);
+            expect(mmmm.hours).to.equal(24);
+            expect(mmmm.days).to.equal(7);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("respects nesting without name collisions", () => {
@@ -88,9 +109,14 @@ describe("Concat", () => {
         const content = "Lizzy+Katrina";
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        assert(isPatternMatch(result));
-        assert(result.name === "Lizzy");
-        assert(result.spouse.name === "Katrina");
+        if (isSuccessfulMatch(result)) {
+            const mmmm = result.match as any;
+            assert(mmmm.name === "Lizzy");
+            assert(mmmm.spouse.name === "Katrina");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("respects nesting without name collisions using nested rep", () => {
@@ -104,10 +130,15 @@ describe("Concat", () => {
         const content = "Lizzy+Katrina,Terri";
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        assert(isPatternMatch(result));
-        assert(result.names[0], "Lizzy");
-        assert(result.spouse.names[0] === "Katrina");
-        assert(result.spouse.names[1] === "Terri");
+        if (isSuccessfulMatch(result)) {
+            const mmmm = result.match as any;
+            assert(mmmm.names[0], "Lizzy");
+            assert(mmmm.spouse.names[0] === "Katrina");
+            assert(mmmm.spouse.names[1] === "Terri");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("respects nesting without name collisions using parallel reps within concats", () => {
@@ -122,10 +153,15 @@ describe("Concat", () => {
         const content = "Jardine vs Bradman,Woodfull";
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        assert(isPatternMatch(result));
-        assert(result.gentlemen.names[0], "Jardine");
-        assert(result.players.names[0] === "Bradman");
-        assert(result.players.names[1] === "Woodfull");
+        if (isSuccessfulMatch(result)) {
+            const mmmm = result.match as any;
+            assert(mmmm.gentlemen.names[0], "Jardine");
+            assert(mmmm.players.names[0] === "Bradman");
+            assert(mmmm.players.names[1] === "Woodfull");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("respects nesting without name collisions using parallel reps without concats", () => {
@@ -137,17 +173,22 @@ describe("Concat", () => {
         const content = "Jardine vs Bradman,Woodfull";
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        assert(isPatternMatch(result));
-        assert(result.gentlemen[0], "Jardine");
-        assert(result.players[0] === "Bradman");
-        assert(result.players[1] === "Woodfull");
+        if (isSuccessfulMatch(result)) {
+            const mmmm = result.match as any;
+            assert(mmmm.gentlemen[0], "Jardine");
+            assert(mmmm.players[0] === "Bradman");
+            assert(mmmm.players[1] === "Woodfull");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("repsep of concat", () => {
         const nameList = {
             names: new Rep1Sep({
                 name: /[A-Za-z]+/,
-                lp : "(",
+                lp: "(",
                 plays: new Rep1Sep(/[a-z]+/, ","),
                 rp: ")",
             }, ","),
@@ -160,14 +201,19 @@ describe("Concat", () => {
         const content = "Jardine(bat),Wyatt(bat) vs Bradman(bat,bowl),Woodfull(bat,keep)";
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;
-        assert(isPatternMatch(result));
-        assert(result.gentlemen.names[0].name, "Jardine");
-        assert(result.players.names[0].name === "Bradman");
-        assert(result.players.names[1].name === "Woodfull");
-        assert(result.players.names[1].plays[0] = "bat");
-        // Don't pollute higher level namespace
-        assert(result.name === undefined);
-        assert(result.gentlemen.name === undefined, "Don't pollute parent namespace");
+        if (isSuccessfulMatch(result)) {
+            const mmmm = result.match as any;
+            assert(mmmm.gentlemen.names[0].name, "Jardine");
+            assert(mmmm.players.names[0].name === "Bradman");
+            assert(mmmm.players.names[1].name === "Woodfull");
+            assert(mmmm.players.names[1].plays[0] = "bat");
+            // Don't pollute higher level namespace
+            assert(mmmm.name === undefined);
+            assert(mmmm.gentlemen.name === undefined, "Don't pollute parent namespace");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("rep array structure", () => {
@@ -179,11 +225,16 @@ describe("Concat", () => {
         });
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as PatternMatch;
-        expect(isPatternMatch(result)).to.equal(true);
-        const r = result as any;
-        expect(r.name).to.equal("Donald");
-        expect(r.delim).to.equal(":");
-        expect(r.hobbies).to.have.members(["golf", "tweeting"]);
+        if (isSuccessfulMatch(result)) {
+            const mmmm = result.match as any;
+            const r = mmmm as any;
+            expect(r.name).to.equal("Donald");
+            expect(r.delim).to.equal(":");
+            expect(r.hobbies).to.have.members(["golf", "tweeting"]);
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("does not allow undefined matcher field steps", () => {

--- a/test/matchers/ConcatTest.ts
+++ b/test/matchers/ConcatTest.ts
@@ -26,7 +26,7 @@ describe("Concat", () => {
         const content = "2";
         const mg = new Concat({
             $id: "Foo",
-            num: /^[1-9][0-9]*/,
+            num: /[1-9][0-9]*/,
         } as Term);
         const is = inputStateFromString(content);
         const result = mg.matchPrefix(is, {}) as any;

--- a/test/matchers/java/JavaBlockMicrogrammarTest.ts
+++ b/test/matchers/java/JavaBlockMicrogrammarTest.ts
@@ -20,7 +20,7 @@ describe("JavaBlock microgrammars", () => {
  * Note that these grammars aren't meant to be realistic
  */
 
-export const JAVA_IDENTIFIER = /^[A-Za-z][a-zA-Z0-9]+/;
+export const JAVA_IDENTIFIER = /[A-Za-z][a-zA-Z0-9]+/;
 
 const METHOD_GRAMMAR = Microgrammar.fromDefinitions<ChangeControledMethod>({
     _visibilityModifier: "public",

--- a/test/matchers/java/JavaBlockTest.ts
+++ b/test/matchers/java/JavaBlockTest.ts
@@ -78,9 +78,9 @@ describe("JavaBlock", () => {
                        const mmmm = m.match as any;
                        assert(mmmm.$matched === balanced);
                        assert(mmmm.block.left === "x");
-                       assert(mmmm.block.left$match.$offset === 2);
+                       assert(mmmm.block.$value.left$match.$offset === 2);
                        assert(mmmm.block.right === "y");
-                       assert(mmmm.block.right$match.$offset === 6);
+                       assert(mmmm.block.$value.right$match.$offset === 6);
 
                     } else {
                        assert.fail("Didn't match");

--- a/test/matchers/java/JavaBlockTest.ts
+++ b/test/matchers/java/JavaBlockTest.ts
@@ -54,7 +54,7 @@ describe("JavaBlock", () => {
     it("should match till balance", () => {
         const balanced = "{  x = y; { }  2; }";
         const is = inputStateFromString(balanced + "// this is a comment }");
-        const m = JavaBlock.matchPrefix(is, {}) as PatternMatch;
+        const m = JavaBlock.matchPrefix(is) as PatternMatch;
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$matched === balanced);
@@ -73,7 +73,7 @@ describe("JavaBlock", () => {
             right: "y",
             _whatever: new Break("//////"),
         });
-        const m: any = javaBlockContaining(inner.matcher).matchPrefix(is, {});
+        const m: any = javaBlockContaining(inner.matcher).matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$matched === balanced);
@@ -89,7 +89,7 @@ describe("JavaBlock", () => {
 
     function match(what: string) {
         const is = inputStateFromString(what);
-        const m = JavaBlock.matchPrefix(is, {}) as PatternMatch;
+        const m = JavaBlock.matchPrefix(is) as PatternMatch;
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$matched === what);
@@ -101,7 +101,7 @@ describe("JavaBlock", () => {
 
     function shouldNotMatch(what: string) {
         const is = inputStateFromString(what);
-        const m = JavaBlock.matchPrefix(is, {});
+        const m = JavaBlock.matchPrefix(is);
         assert(!isSuccessfulMatch(m));
     }
 

--- a/test/matchers/java/JavaBlockTest.ts
+++ b/test/matchers/java/JavaBlockTest.ts
@@ -78,9 +78,9 @@ describe("JavaBlock", () => {
                        const mmmm = m.match as any;
                        assert(mmmm.$matched === balanced);
                        assert(mmmm.block.left === "x");
-                       assert(mmmm.block.$value.left$match.$offset === 2);
+                       assert(mmmm.block.$valueMatches.left.$offset === 2);
                        assert(mmmm.block.right === "y");
-                       assert(mmmm.block.$value.right$match.$offset === 6);
+                       assert(mmmm.block.$valueMatches.right.$offset === 6);
 
                     } else {
                        assert.fail("Didn't match");

--- a/test/matchers/java/JavaBlockTest.ts
+++ b/test/matchers/java/JavaBlockTest.ts
@@ -1,7 +1,7 @@
 
 import { JavaBlock, javaBlockContaining } from "../../../src/matchers/java/JavaBody";
 import { Microgrammar } from "../../../src/Microgrammar";
-import { isPatternMatch, PatternMatch } from "../../../src/PatternMatch";
+import {  PatternMatch } from "../../../src/PatternMatch";
 import { Regex } from "../../../src/Primitives";
 
 import { Break } from "../../../src/matchers/snobol/Break";
@@ -9,6 +9,7 @@ import { Break } from "../../../src/matchers/snobol/Break";
 import { inputStateFromString } from "../../../src/internal/InputStateFactory";
 
 import * as assert from "power-assert";
+import {isSuccessfulMatch} from "../../../src/MatchPrefixResult";
 
 describe("JavaBlock", () => {
 
@@ -54,9 +55,14 @@ describe("JavaBlock", () => {
         const balanced = "{  x = y; { }  2; }";
         const is = inputStateFromString(balanced + "// this is a comment }");
         const m = JavaBlock.matchPrefix(is, {}) as PatternMatch;
-        assert(isPatternMatch(m));
-        assert(m.$matched === balanced);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert(mmmm.$matched === balanced);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("should match inner structure", () => {
         const balanced = "{ x = y; }";
@@ -68,25 +74,35 @@ describe("JavaBlock", () => {
             _whatever: new Break("//////"),
         });
         const m: any = javaBlockContaining(inner.matcher).matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert(m.$matched === balanced);
-        assert(m.block.left === "x");
-        assert(m.block.left$match.$offset === 2);
-        assert(m.block.right === "y");
-        assert(m.block.right$match.$offset === 6);
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert(mmmm.$matched === balanced);
+                       assert(mmmm.block.left === "x");
+                       assert(mmmm.block.left$match.$offset === 2);
+                       assert(mmmm.block.right === "y");
+                       assert(mmmm.block.right$match.$offset === 6);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     function match(what: string) {
         const is = inputStateFromString(what);
         const m = JavaBlock.matchPrefix(is, {}) as PatternMatch;
-        assert(isPatternMatch(m));
-        assert(m.$matched === what);
-    }
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert(mmmm.$matched === what);
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   }
 
     function shouldNotMatch(what: string) {
         const is = inputStateFromString(what);
         const m = JavaBlock.matchPrefix(is, {});
-        assert(!isPatternMatch(m));
+        assert(!isSuccessfulMatch(m));
     }
 
 });

--- a/test/matchers/java/JavaBlockTest.ts
+++ b/test/matchers/java/JavaBlockTest.ts
@@ -62,7 +62,7 @@ describe("JavaBlock", () => {
         const balanced = "{ x = y; }";
         const is = inputStateFromString(balanced);
         const inner = Microgrammar.fromDefinitions({
-            left: new Regex(/^[a-z]+/),
+            left: new Regex(/[a-z]+/),
             equals: "=",
             right: "y",
             _whatever: new Break("//////"),

--- a/test/matchers/skip/SkipTest.ts
+++ b/test/matchers/skip/SkipTest.ts
@@ -2,9 +2,11 @@ import { Microgrammar } from "../../../src/Microgrammar";
 import { Alt } from "../../../src/Ops";
 
 import * as assert from "power-assert";
-import { yadaYadaThen, yadaYadaThenThisButNotThat } from "../../../src/matchers/skip/Skip";
+import { inputStateFromString } from "../../../src/internal/InputStateFactory";
+import { RestOfLine, yadaYadaThen, yadaYadaThenThisButNotThat } from "../../../src/matchers/skip/Skip";
+import { isSuccessfulMatch } from "../../../src/MatchPrefixResult";
 
-describe("fluent builder", () => {
+describe("Skip", () => {
 
     const desirable = Microgrammar.fromDefinitions({
         beast: new Alt("dog", "cat", "pig"),
@@ -25,21 +27,16 @@ describe("fluent builder", () => {
         assert(!m);
     });
 
-    // const depsGrammar = Microgrammar.fromDefinitions<VersionedArtifact>({
-    //     _startElt: yadaYadaThenThisButNotThat("<dependency>", "<dependencyManagement>"),
-    //         ...GAV_CONCAT,
-    //     _bind: ctx => {
-    //         console.log("GAV = " + JSON.stringify(ctx))
-    //         return ctx.dependency = asVersionedArtifact(ctx.tags);
-    //     }
-    // });
-    //
-    // it("handles XML path", () => {
-    //     const pom = POM_WITH_DEPENDENCY_MANAGEMENT;
-    //
-    //     const deps = depsGrammar.findMatches(pom);
-    //     assert(deps.length === 1);
-    //     assert(deps[0].group === "com.foo.bar");
-    // });
+    it("rest of line to end of line", () => {
+        const input = "The quick brown\nfox jumps over\nthe lazy dog";
+        const pm = RestOfLine.matchPrefix(inputStateFromString(input));
+        assert(isSuccessfulMatch(pm) && pm.$matched === "The quick brown");
+    });
+
+    it("rest of line consumes remaining input", () => {
+        const input = "The quick brown fox jumps over the lazy dog";
+        const pm = RestOfLine.matchPrefix(inputStateFromString(input));
+        assert(isSuccessfulMatch(pm) && pm.$matched === input);
+    });
 
 });

--- a/test/matchers/snobol/BreakTest.ts
+++ b/test/matchers/snobol/BreakTest.ts
@@ -22,7 +22,7 @@ describe("Break", () => {
     });
 
     it("break matches another matcher", () => {
-        const b = new Break(new Regex(/^[a-z]/));
+        const b = new Break(new Regex(/[a-z]/));
         const is = inputStateFromString("HEY YOU banana");
         const m = b.matchPrefix(is, {});
         assert(isPatternMatch(m));
@@ -31,7 +31,7 @@ describe("Break", () => {
 
     it("break matches a complicated matcher", () => {
         const b = new Break(
-            new Concat({ $id: "yeah", _start: "${", name: new Regex(/^[a-z]+/), _end: "}" } as Term,
+            new Concat({ $id: "yeah", _start: "${", name: new Regex(/[a-z]+/), _end: "}" } as Term,
                 { consumeWhiteSpaceBetweenTokens: false }));
         const is = inputStateFromString("HEY YOU ${thing} and more stuff");
         const m = b.matchPrefix(is, {});

--- a/test/matchers/snobol/BreakTest.ts
+++ b/test/matchers/snobol/BreakTest.ts
@@ -17,7 +17,7 @@ describe("Break", () => {
     it("break matches exhausted", () => {
         const b = new Break("14");
         const is = inputStateFromString("");
-        const m = b.matchPrefix(is, {});
+        const m = b.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "");
@@ -30,7 +30,7 @@ describe("Break", () => {
     it("break matches another matcher", () => {
         const b = new Break(new Regex(/[a-z]/));
         const is = inputStateFromString("HEY YOU banana");
-        const m = b.matchPrefix(is, {});
+        const m = b.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "HEY YOU ");
@@ -45,7 +45,7 @@ describe("Break", () => {
             new Concat({$id: "yeah", _start: "${", name: new Regex(/[a-z]+/), _end: "}"} as Term,
                 {consumeWhiteSpaceBetweenTokens: false}));
         const is = inputStateFromString("HEY YOU ${thing} and more stuff");
-        const m = b.matchPrefix(is, {});
+        const m = b.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "HEY YOU ");
@@ -58,7 +58,7 @@ describe("Break", () => {
     it("break matches", () => {
         const b = new Break("14");
         const is = inputStateFromString("friday 14");
-        const m = b.matchPrefix(is, {});
+        const m = b.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "friday ");
@@ -71,12 +71,12 @@ describe("Break", () => {
     it("break to Alt", () => {
         const b = new Break(new Alt("14", "44"));
         const is = inputStateFromString("friday 14");
-        const m = b.matchPrefix(is, {});
+        const m = b.matchPrefix(is);
         assert(isSuccessfulMatch(m));
         assert((m as PatternMatch).$matched === "friday ");
 
         const is2 = inputStateFromString("friday 44");
-        const m2 = b.matchPrefix(is2, {});
+        const m2 = b.matchPrefix(is2);
         assert(isSuccessfulMatch(m2));
         assert((m2 as PatternMatch).$matched === "friday ");
     });
@@ -84,7 +84,7 @@ describe("Break", () => {
     it("break matches and consumes", () => {
         const b = new Break("14", true);
         const is = inputStateFromString("friday 14");
-        const m = b.matchPrefix(is, {}) as any;
+        const m = b.matchPrefix(is) as any;
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert(mmmm.$matched === "friday 14");
@@ -98,7 +98,7 @@ describe("Break", () => {
     it("break matches nothing as it comes immediately", () => {
         const b = new Break("friday");
         const is = inputStateFromString("friday 14");
-        const m = b.matchPrefix(is, {});
+        const m = b.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "");
@@ -115,7 +115,7 @@ describe("Break", () => {
             number: new Span("41"),
         });
         const is = inputStateFromString("friday 14");
-        const m = c.matchPrefix(is, {});
+        const m = c.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "friday 14");

--- a/test/matchers/snobol/BreakTest.ts
+++ b/test/matchers/snobol/BreakTest.ts
@@ -1,15 +1,16 @@
-import { Term } from "../../../src/Matchers";
-import { Concat } from "../../../src/matchers/Concat";
-import { isPatternMatch, PatternMatch } from "../../../src/PatternMatch";
-import { Regex } from "../../../src/Primitives";
+import {Term} from "../../../src/Matchers";
+import {Concat} from "../../../src/matchers/Concat";
+import {PatternMatch} from "../../../src/PatternMatch";
+import {Regex} from "../../../src/Primitives";
 
-import { Break } from "../../../src/matchers/snobol/Break";
+import {Break} from "../../../src/matchers/snobol/Break";
 
-import { inputStateFromString } from "../../../src/internal/InputStateFactory";
-import { Span } from "../../../src/matchers/snobol/Span";
-import { Alt } from "../../../src/Ops";
+import {inputStateFromString} from "../../../src/internal/InputStateFactory";
+import {Span} from "../../../src/matchers/snobol/Span";
+import {Alt} from "../../../src/Ops";
 
 import * as assert from "power-assert";
+import {isSuccessfulMatch} from "../../../src/MatchPrefixResult";
 
 describe("Break", () => {
 
@@ -17,46 +18,66 @@ describe("Break", () => {
         const b = new Break("14");
         const is = inputStateFromString("");
         const m = b.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === "");
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === "");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("break matches another matcher", () => {
         const b = new Break(new Regex(/[a-z]/));
         const is = inputStateFromString("HEY YOU banana");
         const m = b.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === "HEY YOU ");
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === "HEY YOU ");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("break matches a complicated matcher", () => {
         const b = new Break(
-            new Concat({ $id: "yeah", _start: "${", name: new Regex(/[a-z]+/), _end: "}" } as Term,
-                { consumeWhiteSpaceBetweenTokens: false }));
+            new Concat({$id: "yeah", _start: "${", name: new Regex(/[a-z]+/), _end: "}"} as Term,
+                {consumeWhiteSpaceBetweenTokens: false}));
         const is = inputStateFromString("HEY YOU ${thing} and more stuff");
         const m = b.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === "HEY YOU ");
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === "HEY YOU ");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("break matches", () => {
         const b = new Break("14");
         const is = inputStateFromString("friday 14");
         const m = b.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === "friday ");
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === "friday ");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("break to Alt", () => {
         const b = new Break(new Alt("14", "44"));
         const is = inputStateFromString("friday 14");
         const m = b.matchPrefix(is, {});
-        assert(isPatternMatch(m));
+        assert(isSuccessfulMatch(m));
         assert((m as PatternMatch).$matched === "friday ");
 
         const is2 = inputStateFromString("friday 44");
         const m2 = b.matchPrefix(is2, {});
-        assert(isPatternMatch(m2));
+        assert(isSuccessfulMatch(m2));
         assert((m2 as PatternMatch).$matched === "friday ");
     });
 
@@ -64,17 +85,27 @@ describe("Break", () => {
         const b = new Break("14", true);
         const is = inputStateFromString("friday 14");
         const m = b.matchPrefix(is, {}) as any;
-        assert(isPatternMatch(m));
-        assert(m.$matched === "friday 14");
-        assert(m.$value === "14");
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            assert(mmmm.$matched === "friday 14");
+            assert(mmmm.$value === "14");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("break matches nothing as it comes immediately", () => {
         const b = new Break("friday");
         const is = inputStateFromString("friday 14");
         const m = b.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === "");
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === "");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
     it("break matches all in concat", () => {
@@ -85,8 +116,14 @@ describe("Break", () => {
         });
         const is = inputStateFromString("friday 14");
         const m = c.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert((m as PatternMatch).$matched === "friday 14");
+        if (isSuccessfulMatch(m)) {
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === "friday 14");
+
+        } else {
+            assert.fail("Didn't match");
+        }
     });
 
-});
+})
+;

--- a/test/matchers/snobol/BreakTest.ts
+++ b/test/matchers/snobol/BreakTest.ts
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { Term } from "../../../src/Matchers";
 import { Concat } from "../../../src/matchers/Concat";
 import { isPatternMatch, PatternMatch } from "../../../src/PatternMatch";
@@ -8,6 +7,9 @@ import { Break } from "../../../src/matchers/snobol/Break";
 
 import { inputStateFromString } from "../../../src/internal/InputStateFactory";
 import { Span } from "../../../src/matchers/snobol/Span";
+import { Alt } from "../../../src/Ops";
+
+import * as assert from "power-assert";
 
 describe("Break", () => {
 
@@ -15,16 +17,16 @@ describe("Break", () => {
         const b = new Break("14");
         const is = inputStateFromString("");
         const m = b.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal("");
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === "");
     });
 
     it("break matches another matcher", () => {
         const b = new Break(new Regex(/^[a-z]/));
         const is = inputStateFromString("HEY YOU banana");
         const m = b.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal("HEY YOU ");
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === "HEY YOU ");
     });
 
     it("break matches a complicated matcher", () => {
@@ -33,33 +35,46 @@ describe("Break", () => {
                 { consumeWhiteSpaceBetweenTokens: false }));
         const is = inputStateFromString("HEY YOU ${thing} and more stuff");
         const m = b.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal("HEY YOU ");
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === "HEY YOU ");
     });
 
     it("break matches", () => {
         const b = new Break("14");
         const is = inputStateFromString("friday 14");
         const m = b.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal("friday ");
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === "friday ");
+    });
+
+    it("break to Alt", () => {
+        const b = new Break(new Alt("14", "44"));
+        const is = inputStateFromString("friday 14");
+        const m = b.matchPrefix(is, {});
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === "friday ");
+
+        const is2 = inputStateFromString("friday 44");
+        const m2 = b.matchPrefix(is2, {});
+        assert(isPatternMatch(m2));
+        assert((m2 as PatternMatch).$matched === "friday ");
     });
 
     it("break matches and consumes", () => {
         const b = new Break("14", true);
         const is = inputStateFromString("friday 14");
         const m = b.matchPrefix(is, {}) as any;
-        expect(isPatternMatch(m)).to.equal(true);
-        expect(m.$matched).to.equal("friday 14");
-        expect(m.$value).to.equal("14");
+        assert(isPatternMatch(m));
+        assert(m.$matched === "friday 14");
+        assert(m.$value === "14");
     });
 
     it("break matches nothing as it comes immediately", () => {
         const b = new Break("friday");
         const is = inputStateFromString("friday 14");
         const m = b.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal("");
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === "");
     });
 
     it("break matches all in concat", () => {
@@ -70,8 +85,8 @@ describe("Break", () => {
         });
         const is = inputStateFromString("friday 14");
         const m = c.matchPrefix(is, {});
-        expect(isPatternMatch(m)).to.equal(true);
-        expect((m as PatternMatch).$matched).to.equal("friday 14");
+        assert(isPatternMatch(m));
+        assert((m as PatternMatch).$matched === "friday 14");
     });
 
 });

--- a/test/matchers/snobol/BreakTest.ts
+++ b/test/matchers/snobol/BreakTest.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
-import { Concat } from "../../../src/Concat";
 import { Term } from "../../../src/Matchers";
+import { Concat } from "../../../src/matchers/Concat";
 import { isPatternMatch, PatternMatch } from "../../../src/PatternMatch";
 import { Regex } from "../../../src/Primitives";
 

--- a/test/matchers/snobol/BreakTest.ts
+++ b/test/matchers/snobol/BreakTest.ts
@@ -1,7 +1,7 @@
 import {Term} from "../../../src/Matchers";
 import {Concat} from "../../../src/matchers/Concat";
 import {PatternMatch} from "../../../src/PatternMatch";
-import {Regex} from "../../../src/Primitives";
+import { Integer, Regex } from "../../../src/Primitives";
 
 import {Break} from "../../../src/matchers/snobol/Break";
 
@@ -93,6 +93,15 @@ describe("Break", () => {
         } else {
             assert.fail("Didn't match");
         }
+    });
+
+    it("break and consume uses value", () => {
+        const b = new Break(Integer, true);
+        const is = inputStateFromString("friday 14");
+        const m = b.matchPrefix(is) as any;
+        assert(isSuccessfulMatch(m));
+        assert(m.$matched === "friday 14");
+        assert(m.$value === 14);
     });
 
     it("break matches nothing as it comes immediately", () => {

--- a/test/matchers/snobol/SpanTest.ts
+++ b/test/matchers/snobol/SpanTest.ts
@@ -1,10 +1,9 @@
 import * as assert from "power-assert";
 
-import { isPatternMatch } from "../../../src/PatternMatch";
-
 import { Span } from "../../../src/matchers/snobol/Span";
 
 import { inputStateFromString } from "../../../src/internal/InputStateFactory";
+import {isSuccessfulMatch} from "../../../src/MatchPrefixResult";
 
 describe("Span", () => {
 
@@ -12,25 +11,35 @@ describe("Span", () => {
         const span = new Span("abcd");
         const is = inputStateFromString("friday 14");
         const m = span.matchPrefix(is, {});
-        assert(!isPatternMatch(m));
+        assert(!isSuccessfulMatch(m));
     });
 
     it("span match when first char matches", () => {
         const span = new Span("abcdef");
         const is = inputStateFromString("friday 14");
         const m = span.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert(m.$offset === 0);
-        assert((m as any).$matched === "f");
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert(mmmm.$offset === 0);
+                       assert((m as any).$matched === "f");
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
     it("span match when some characters match", () => {
         const span = new Span("rabcdefi1");
         const is = inputStateFromString("friday 14");
         const m = span.matchPrefix(is, {});
-        assert(isPatternMatch(m));
-        assert(m.$offset === 0);
-        assert((m as any).$matched === "frida");
-    });
+        if (isSuccessfulMatch(m)) {
+                       const mmmm = m.match as any;
+                       assert(mmmm.$offset === 0);
+                       assert((m as any).$matched === "frida");
+
+                    } else {
+                       assert.fail("Didn't match");
+                    }
+                   });
 
 });

--- a/test/matchers/snobol/SpanTest.ts
+++ b/test/matchers/snobol/SpanTest.ts
@@ -10,14 +10,14 @@ describe("Span", () => {
     it("span no match when no single char", () => {
         const span = new Span("abcd");
         const is = inputStateFromString("friday 14");
-        const m = span.matchPrefix(is, {});
+        const m = span.matchPrefix(is);
         assert(!isSuccessfulMatch(m));
     });
 
     it("span match when first char matches", () => {
         const span = new Span("abcdef");
         const is = inputStateFromString("friday 14");
-        const m = span.matchPrefix(is, {});
+        const m = span.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$offset === 0);
@@ -31,7 +31,7 @@ describe("Span", () => {
     it("span match when some characters match", () => {
         const span = new Span("rabcdefi1");
         const is = inputStateFromString("friday 14");
-        const m = span.matchPrefix(is, {});
+        const m = span.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$offset === 0);


### PR DESCRIPTION
DO NOT MERGE - I'll merge everyone else's changes into this once it's approved. I'll also update the changelog then.

This refactoring was triggered by a bug, that a concat inside an alt inside a concat wasn't getting its fields in the right place.

That required returning more than the PatternMatch from matchPrefix.
`matchPrefix` is the internal function, the one we call on nested matchers. As opposed to `findMatches` (and a few others) which are the public interface.
The public methods return `PatternMatch`
but now `findMatches` returns `SuccessfulMatch` (a superclass of `MatchPrefixResult`) if it succeeds; this can also include a context.

that's the top level. Underneath, some of the structure of PatternMatch data is different. (and, I hope, more consistent.)

Rod already made it so `context` was only input to the constructor of PatternMatch and not exposed. I made it so `context` is only input to TreePatternMatch. Its purpose (at that point) is to hold fields that the user asked us to add to the match object. Prior to that, `context` has the purpose of accumulating data from earlier in the match and let functions inside the grammar use this to either add fields or veto the match. This is only used in Concat.

Here are more fun changes:
* $match is never populated anymore. This prevents JSON.stringify failing; they were circular references. Any nested matches are PatternMatch already; we don't need to provide that separately. This is fine because Rod cleaned up that interface the other day. 
* nested values (as opposed to nested matches) have their PatternMatch objects stored in a $valueMatches object. This used to be, for a field called `city`, in a `city$match` property. Now it's `$valueMatches.city`. This means it'll be excluded from the matchStructure.
* there were some places where we checked whether values were typeof "object." This does not work. Arrays are objects. I'm replacing those with "is there a context defined in the SuccessfulMatch" and isPatternMatch and isTreePatternMatch, as appropriate.

These are less fun but they're simplifying:
* Removed the `pullUp` feature from Opt; it's easy to use an alter function for this
* Removed TransformingMatcher; it's easy to use an alter function instead.
 
Enablement for the future: better distinguish terminal from parent PatternMatches. In particular, Rep should not return a TerminalPatternMatch, because it has an array of matches. Implementing that differently will let me implement update for matchers inside a Rep, which is currently not possible at all. 