### PR TITLE
Two-level context and config overhaul

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,17 +1,24 @@
+
 /**
- * Configuration for a grammar or configurable matcher
+ * Config properties. Mix these into Concats or make other matchers
+ * implement the relevant interfaces.
  */
-export interface Config {
 
-    consumeWhiteSpaceBetweenTokens: boolean;
+/**
+ * Implemented by matchers with configurable whitespace handling.
+ */
+export interface WhiteSpaceHandler {
+
+    $consumeWhiteSpaceBetweenTokens: boolean;
 
 }
 
-export const DefaultConfig: Config = {
-    consumeWhiteSpaceBetweenTokens: true,
+/**
+ * Object literals that provide concats can bring this in
+ * via a spread to get white space sensitivity
+ * @type {{consumeWhiteSpaceBetweenTokens: boolean}}
+ */
+export const WhiteSpaceSensitive: WhiteSpaceHandler = {
+
+    $consumeWhiteSpaceBetweenTokens: false,
 };
-
-export interface Configurable {
-
-    withConfig(config: Config): this;
-}

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -22,3 +22,21 @@ export const WhiteSpaceSensitive: WhiteSpaceHandler = {
 
     $consumeWhiteSpaceBetweenTokens: false,
 };
+
+export interface SkipCapable {
+
+    /**
+     * Should we skip between productions?
+     */
+    $skipGaps: boolean;
+}
+
+/**
+ * Skip between productions.
+ * @type {{$skipGaps: boolean}}
+ */
+export const Skipper: SkipCapable = {
+
+    $skipGaps: true,
+
+};

--- a/src/MatchPrefixResult.ts
+++ b/src/MatchPrefixResult.ts
@@ -1,4 +1,4 @@
-import {PatternMatch} from "./PatternMatch";
+import { PatternMatch } from "./PatternMatch";
 
 /**
  * Result of attempting to match a pattern: MatchFailureReport or SuccessfulMatch.

--- a/src/Matchers.ts
+++ b/src/Matchers.ts
@@ -27,12 +27,14 @@ export interface MatchingLogic extends Term {
 
     /**
      * Core matching method. Can we match at the present point in the
-     * given InputState
+     * given InputState? Context arguments may be used by matchers that
+     * require knowledge of current match or global context.
      * @param is input state
-     * @param context context: What's already bound by other matchers,
-     * and what this matcher should bind to if it wishes
+     * @param thisMatchContext context for this match, beginning from the top level and
+     * passed into nested matchers
+     * @param parseContext context for the whole parsing operation we're in: e.g. parsing a file
      */
-    matchPrefix(is: InputState): MatchPrefixResult;
+    matchPrefix(is: InputState, thisMatchContext: {}, parseContext: {}): MatchPrefixResult;
 
     /**
      * Optimization method. Can a match start with this character?

--- a/src/Microgrammar.ts
+++ b/src/Microgrammar.ts
@@ -3,7 +3,7 @@ import { InputState } from "./InputState";
 import { MatchingLogic, Term } from "./Matchers";
 import { Concat, toMatchingLogic } from "./matchers/Concat";
 import { isSuccessfulMatch } from "./MatchPrefixResult";
-import {DismatchReport,  PatternMatch} from "./PatternMatch";
+import { DismatchReport, PatternMatch } from "./PatternMatch";
 
 import { InputStream } from "./spi/InputStream";
 import { StringInputStream } from "./spi/StringInputStream";

--- a/src/Microgrammar.ts
+++ b/src/Microgrammar.ts
@@ -37,6 +37,7 @@ export class Updatable<T> {
 }
 
 /**
+ * Central class for microgrammar usage.
  * Represents a microgrammar that we can use to match input
  * in a string or stream.
  * Modifications are tracked and we can get an updated string

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -32,13 +32,13 @@ export class Opt implements MatchingLogic {
         return `Opt[${this.matcher.$id}]`;
     }
 
-    public matchPrefix(is: InputState): MatchPrefixResult {
+    public matchPrefix(is: InputState, thisMatchContext, parseContext): MatchPrefixResult {
         if (is.exhausted()) {
             // console.log(`Match from Opt on exhausted stream`);
             return matchPrefixSuccess(new UndefinedPatternMatch(this.$id, is.offset));
         }
 
-        const maybe = this.matcher.matchPrefix(is);
+        const maybe = this.matcher.matchPrefix(is, thisMatchContext, parseContext);
         if (isSuccessfulMatch(maybe)) {
             return maybe;
         }
@@ -63,13 +63,13 @@ export class Alt implements MatchingLogic {
         return `Alt(${this.matchers.map(m => m.$id).join(",")})`;
     }
 
-    public matchPrefix(is: InputState): MatchPrefixResult {
+    public matchPrefix(is: InputState, thisMatchContext, parseContext): MatchPrefixResult {
         if (is.exhausted()) {
             return new MatchFailureReport(this.$id, is.offset, {});
         }
 
         for (const matcher of this.matchers) {
-            const m = matcher.matchPrefix(is);
+            const m = matcher.matchPrefix(is, thisMatchContext, parseContext);
             if (isSuccessfulMatch(m)) {
                 return m;
             }
@@ -96,8 +96,8 @@ export function when(o: any, matchTest: (PatternMatch) => boolean) {
         }
     }
 
-    function conditionalMatch(is: InputState, context: {}): MatchPrefixResult {
-        const result = matcher.matchPrefix(is);
+    function conditionalMatch(is: InputState, thisMatchContext, parseContext): MatchPrefixResult {
+        const result = matcher.matchPrefix(is, thisMatchContext, parseContext);
         return (isSuccessfulMatch(result) && matchTest(result.match)) ?
             result :
             new MatchFailureReport(this.$id, is.offset, context);

--- a/src/Ops.ts
+++ b/src/Ops.ts
@@ -1,8 +1,8 @@
-import {InputState} from "./InputState";
-import {MatchingLogic} from "./Matchers";
-import {toMatchingLogic} from "./matchers/Concat";
-import {isSuccessfulMatch, MatchFailureReport, MatchPrefixResult, matchPrefixSuccess} from "./MatchPrefixResult";
-import {UndefinedPatternMatch} from "./PatternMatch";
+import { InputState } from "./InputState";
+import { MatchingLogic } from "./Matchers";
+import { toMatchingLogic } from "./matchers/Concat";
+import { isSuccessfulMatch, MatchFailureReport, MatchPrefixResult, matchPrefixSuccess } from "./MatchPrefixResult";
+import { UndefinedPatternMatch } from "./PatternMatch";
 
 /**
  * Optional match on the given matcher

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -29,7 +29,6 @@ export abstract class PatternMatch {
      * @param $matcherId id of the matcher that matched
      * @param $matched the actual string content
      * @param $offset offset from 0 in input
-     * @param $context context bound during the match
      */
     constructor(public readonly $matcherId: string,
                 public readonly $matched: string,

--- a/src/PatternMatch.ts
+++ b/src/PatternMatch.ts
@@ -1,4 +1,4 @@
-import {Matcher} from "./Matchers";
+import { Matcher } from "./Matchers";
 
 /**
  * Returned when we failed to match prefix

--- a/src/Primitives.ts
+++ b/src/Primitives.ts
@@ -1,7 +1,7 @@
 import { InputState } from "./InputState";
 import { MatchingLogic } from "./Matchers";
-import {MatchFailureReport, MatchPrefixResult, matchPrefixSuccess} from "./MatchPrefixResult";
-import {  TerminalPatternMatch } from "./PatternMatch";
+import { MatchFailureReport, MatchPrefixResult, matchPrefixSuccess } from "./MatchPrefixResult";
+import { TerminalPatternMatch } from "./PatternMatch";
 
 /**
  * Match a literal string

--- a/src/Rep.ts
+++ b/src/Rep.ts
@@ -1,10 +1,9 @@
 import { Config, Configurable, DefaultConfig } from "./Config";
 import { InputState } from "./InputState";
-import { MatchingLogic} from "./Matchers";
-import { isConcat, toMatchingLogic } from "./matchers/Concat";
-import { isSuccessfulMatch } from "./MatchPrefixResult";
-import {MatchFailureReport, MatchPrefixResult, matchPrefixSuccess} from "./MatchPrefixResult";
-import {  PatternMatch, TerminalPatternMatch } from "./PatternMatch";
+import { MatchingLogic } from "./Matchers";
+import { toMatchingLogic } from "./matchers/Concat";
+import { isSuccessfulMatch, MatchFailureReport, MatchPrefixResult, matchPrefixSuccess } from "./MatchPrefixResult";
+import { PatternMatch, TerminalPatternMatch } from "./PatternMatch";
 
 import { readyToMatch } from "./internal/Whitespace";
 

--- a/src/Rep.ts
+++ b/src/Rep.ts
@@ -9,6 +9,24 @@ import {  PatternMatch, TerminalPatternMatch } from "./PatternMatch";
 import { readyToMatch } from "./internal/Whitespace";
 
 /**
+ * Match zero or more of these
+ * @param o matcher
+ * @return {Rep1}
+ */
+export function zeroOrMore(o: any): Repetition {
+    return new Rep(o);
+}
+
+/**
+ * Match at least one of these
+ * @param o matcher
+ * @return {Rep1}
+ */
+export function atLeastOne(o: any): Repetition {
+    return new Rep1(o);
+}
+
+/**
  * Handle repetition, with or without a separator.
  * Prefer subclasses for simplicity and clarity.
  * By default, match zero or more times without a separator

--- a/src/Rep.ts
+++ b/src/Rep.ts
@@ -54,7 +54,7 @@ export class Repetition implements MatchingLogic, Configurable {
             this.matcher.requiredPrefix;
     }
 
-    public matchPrefix(is: InputState): MatchPrefixResult {
+    public matchPrefix(is: InputState, thisMatchContext, parseContext): MatchPrefixResult {
         let currentInputState = is;
         const matches: PatternMatch[] = [];
         let matched = "";
@@ -63,7 +63,7 @@ export class Repetition implements MatchingLogic, Configurable {
             currentInputState = eat.state;
             matched += eat.skipped;
 
-            const result = this.matcher.matchPrefix(currentInputState);
+            const result = this.matcher.matchPrefix(currentInputState, thisMatchContext, parseContext);
             if (!isSuccessfulMatch(result)) {
                 break;
             } else {
@@ -81,7 +81,7 @@ export class Repetition implements MatchingLogic, Configurable {
                 const eaten = readyToMatch(currentInputState, this.config);
                 currentInputState = eaten.state;
                 matched += eaten.skipped;
-                const sepMatchResult = this.sepMatcher.matchPrefix(currentInputState);
+                const sepMatchResult = this.sepMatcher.matchPrefix(currentInputState, thisMatchContext, parseContext);
                 if (isSuccessfulMatch(sepMatchResult)) {
                     const sepMatch = sepMatchResult.match;
                     currentInputState = currentInputState.consume(sepMatch.$matched);

--- a/src/internal/ExactMatch.ts
+++ b/src/internal/ExactMatch.ts
@@ -1,11 +1,11 @@
-import {MatchingLogic} from "../Matchers";
-import {Concat} from "../matchers/Concat";
-import {RestOfInput} from "../matchers/skip/Skip";
-import {isSuccessfulMatch, MatchFailureReport} from "../MatchPrefixResult";
-import {DismatchReport, PatternMatch} from "../PatternMatch";
-import {InputStream} from "../spi/InputStream";
-import {StringInputStream} from "../spi/StringInputStream";
-import {inputStateFromStream} from "./InputStateFactory";
+import { MatchingLogic } from "../Matchers";
+import { Concat } from "../matchers/Concat";
+import { RestOfInput } from "../matchers/skip/Skip";
+import { isSuccessfulMatch, MatchFailureReport } from "../MatchPrefixResult";
+import { DismatchReport, PatternMatch } from "../PatternMatch";
+import { InputStream } from "../spi/InputStream";
+import { StringInputStream } from "../spi/StringInputStream";
+import { inputStateFromStream } from "./InputStateFactory";
 
 export function exactMatch<T>(matcher: MatchingLogic, input: string | InputStream,
                               parseContext = {}): PatternMatch & T | DismatchReport {

--- a/src/internal/ExactMatch.ts
+++ b/src/internal/ExactMatch.ts
@@ -7,13 +7,14 @@ import {InputStream} from "../spi/InputStream";
 import {StringInputStream} from "../spi/StringInputStream";
 import {inputStateFromStream} from "./InputStateFactory";
 
-export function exactMatch<T>(matcher: MatchingLogic, input: string | InputStream): PatternMatch & T | DismatchReport {
+export function exactMatch<T>(matcher: MatchingLogic, input: string | InputStream,
+                              parseContext = {}): PatternMatch & T | DismatchReport {
 
     const wrapped = new Concat({
         desired: matcher,
         trailingJunk: RestOfInput,
     });
-    const result = wrapped.matchPrefix(inputStateFromStream(toInputStream(input)));
+    const result = wrapped.matchPrefix(inputStateFromStream(toInputStream(input)), {}, parseContext);
 
     if (isSuccessfulMatch(result)) {
         const detyped = result.match as any;

--- a/src/internal/InputStateFactory.ts
+++ b/src/internal/InputStateFactory.ts
@@ -1,11 +1,9 @@
 import { InputState } from "../InputState";
 import { StringInputStream } from "../spi/StringInputStream";
 
+import { InputStream } from "../spi/InputStream";
 import { DefaultInputState } from "./DefaultInputState";
 import { InputStateManager } from "./InputStateManager";
-
-import { PatternMatch } from "../PatternMatch";
-import { InputStream } from "../spi/InputStream";
 
 /**
  * Return an input state from a string

--- a/src/internal/MatcherPrinter.ts
+++ b/src/internal/MatcherPrinter.ts
@@ -1,8 +1,8 @@
-import {Matcher, MatchingLogic} from "../Matchers";
-import {Concat, isNamedMatcher, MatchStep} from "../matchers/Concat";
+import { Matcher, MatchingLogic } from "../Matchers";
+import { Concat, isNamedMatcher, MatchStep } from "../matchers/Concat";
+import { isBreak } from "../matchers/snobol/Break";
+import { isLiteral } from "../Primitives";
 import Match = Chai.Match;
-import {isBreak} from "../matchers/snobol/Break";
-import {isLiteral} from "../Primitives";
 
 /**
  * Print a matcher structure

--- a/src/internal/MicrogrammarSpecParser.ts
+++ b/src/internal/MicrogrammarSpecParser.ts
@@ -1,12 +1,12 @@
-import {Config, DefaultConfig} from "../Config";
-import {MatchingLogic} from "../Matchers";
-import {Concat, toMatchingLogic} from "../matchers/Concat";
-import {Literal} from "../Primitives";
+import { Config, DefaultConfig } from "../Config";
+import { MatchingLogic } from "../Matchers";
+import { Concat, toMatchingLogic } from "../matchers/Concat";
+import { Literal } from "../Primitives";
 
-import {Break} from "../matchers/snobol/Break";
-import {isPatternMatch} from "../PatternMatch";
-import {exactMatch} from "./ExactMatch";
-import {MicrogrammarSpec, specGrammar} from "./SpecGrammar";
+import { Break } from "../matchers/snobol/Break";
+import { isPatternMatch } from "../PatternMatch";
+import { exactMatch } from "./ExactMatch";
+import { MicrogrammarSpec, specGrammar } from "./SpecGrammar";
 
 /**
  * Parses microgrammars expressed as strings.

--- a/src/internal/MicrogrammarSpecParser.ts
+++ b/src/internal/MicrogrammarSpecParser.ts
@@ -1,8 +1,8 @@
-import { Config, DefaultConfig } from "../Config";
 import { MatchingLogic } from "../Matchers";
 import { Concat, toMatchingLogic } from "../matchers/Concat";
 import { Literal } from "../Primitives";
 
+import { WhiteSpaceHandler } from "../Config";
 import { Break } from "../matchers/snobol/Break";
 import { isPatternMatch } from "../PatternMatch";
 import { exactMatch } from "./ExactMatch";
@@ -15,36 +15,38 @@ export class MicrogrammarSpecParser {
 
     private anonFieldCount = 0;
 
-    public fromString(spec: string, elements: object = {}, config: Config = DefaultConfig): Concat {
-
+    public fromString(spec: string, elements: object = {}): Concat {
         const mpr = exactMatch<MicrogrammarSpec>(specGrammar, spec);
         if (!isPatternMatch(mpr)) {
             throw new Error(`Unable to parse microgrammar: ${spec}`);
         }
         const match = mpr as MicrogrammarSpec;
-
-        const matcherSequence1 = this.definitionSpecsFromMicrogrammarSpec(match, config);
-
+        const matcherSequence1 = this.definitionSpecsFromMicrogrammarSpec(match,
+            (elements as WhiteSpaceHandler).$consumeWhiteSpaceBetweenTokens !== false);
         const matcherSequence2 = this.populateSpecifiedElements(elements, matcherSequence1);
-
         const matcherSequence3 = this.inferUnspecifiedElements(matcherSequence2);
-
         const definitions = this.definitionsFromSpecs(spec, matcherSequence3);
-
-        return new Concat(definitions, config);
+        const concat = new Concat(definitions);
+        // Copy config to Concat
+        for (const key in elements) {
+            if (key.charAt(0) === "$") {
+                concat[key] = elements[key];
+            }
+        }
+        return concat;
     }
 
-    private definitionSpecsFromMicrogrammarSpec(match: MicrogrammarSpec, config: Config): DefinitionSpec[] {
+    private definitionSpecsFromMicrogrammarSpec(match: MicrogrammarSpec, consumeWhiteSpaceBetweenTokens: boolean): DefinitionSpec[] {
         // flatMap would work better here
         const matcherSequence1: DefinitionSpec[] = [];
         match.these.forEach(
             t => {
                 if (t.literal.length > 0) {
-                    matcherSequence1.push({anonymous: this.matcherForLiteral(t.literal, config)});
+                    matcherSequence1.push({anonymous: this.matcherForLiteral(t.literal, consumeWhiteSpaceBetweenTokens)});
                 }
                 matcherSequence1.push({reference: t.element.elementName});
             });
-        matcherSequence1.push({anonymous: this.matcherForLiteral(match.trailing, config)});
+        matcherSequence1.push({anonymous: this.matcherForLiteral(match.trailing, consumeWhiteSpaceBetweenTokens)});
         return matcherSequence1;
     }
 
@@ -100,8 +102,8 @@ export class MicrogrammarSpecParser {
         return definitions;
     }
 
-    private matcherForLiteral(literal: string, config: Config) {
-        if (!config.consumeWhiteSpaceBetweenTokens) {
+    private matcherForLiteral(literal: string, consumeWhiteSpaceBetweenTokens: boolean) {
+        if (!consumeWhiteSpaceBetweenTokens) {
             return new Literal(literal);
         }
         // TODO why, if we don't put this in, does it fail?

--- a/src/internal/MicrogrammarUpdates.ts
+++ b/src/internal/MicrogrammarUpdates.ts
@@ -76,7 +76,7 @@ export class MicrogrammarUpdates {
                 });
             }
         } else {
-            //console.log(`Not a tree pattern match: ${JSON.stringify(match)}`);
+            // console.log(`Not a tree pattern match: ${JSON.stringify(match)}`);
         }
     }
 }

--- a/src/internal/MicrogrammarUpdates.ts
+++ b/src/internal/MicrogrammarUpdates.ts
@@ -23,7 +23,6 @@ export class MicrogrammarUpdates {
                 this.$changeSet.change(match, newValue);
             },
         };
-        console.log("The top level match target is " + JSON.stringify(match));
         this.addMatchesAsProperties(updating, updating.$changeSet, match);
         return updating as (T & MatchUpdater);
     }
@@ -39,15 +38,12 @@ export class MicrogrammarUpdates {
             const submatches = match.submatches();
             // tslint:disable-next-line:forin
             for (const key in submatches) {
-                console.log(`Making property for ${key}`);
                 const submatch = submatches[key] as PatternMatch;
                 let initialValue;
                 if (isTreePatternMatch(submatch) && submatch.submatches() === {}) {
-                    console.log(" It's a tree with no submatches");
                     initialValue = submatch.$matched; // or $value ? they should both be the string value.
                     // this could also be derived from content + offset, which reduces memory consumption
                 } else {
-                    console.log(" adding nested properties" + JSON.stringify(submatch));
                     initialValue = {};
                     this.addMatchesAsProperties(initialValue, cs, submatch);
                 }
@@ -80,7 +76,7 @@ export class MicrogrammarUpdates {
                 });
             }
         } else {
-            console.log(`Not a tree pattern match: ${JSON.stringify(match)}`);
+            //console.log(`Not a tree pattern match: ${JSON.stringify(match)}`);
         }
     }
 }

--- a/src/internal/Whitespace.ts
+++ b/src/internal/Whitespace.ts
@@ -1,24 +1,23 @@
 import { InputState, Skipped } from "../InputState";
 import { MatchingLogic } from "../Matchers";
 
-import { Config, DefaultConfig } from "../Config";
-
 /**
  * Prepare to match. Skip whitespace if appropriate. Skip irrelevant content if
  * we have a matcher we're preparing for.
  * @param is current input state
- * @param config config, which tells us whether we should skipWhile whitespace
+ * @param consumeWhiteSpaceBetweenTokens should we skipWhile whitespace
  * @param matchers matchers we want to match. If there are multiple matchers,
  * we calculate the longest common prefix (if known). Undefined array
  * elements are ignored, after the first matcher.
  * If there is a definite prefix, we can skipWhile content.
  */
-export function readyToMatch(is: InputState, config: Config = DefaultConfig,
+export function readyToMatch(is: InputState,
+                             consumeWhiteSpaceBetweenTokens: boolean,
                              ...matchers: MatchingLogic[]): Skipped {
     const lookFor = commonPrefix(matchers);
     if (lookFor) {
         return is.skipTo(lookFor);
-    } else if (config.consumeWhiteSpaceBetweenTokens) {
+    } else if (consumeWhiteSpaceBetweenTokens) {
         return is.skipWhile(c => c.trim() === "", 1); // || m && m.canStartWith && !m.canStartWith(c));
     } else {
         return { skipped: "", state: is };

--- a/src/matchers/Concat.ts
+++ b/src/matchers/Concat.ts
@@ -1,10 +1,9 @@
 import { Config, DefaultConfig } from "../Config";
 import { InputState } from "../InputState";
 import { Matcher, MatchingLogic, Term } from "../Matchers";
-import {isSuccessfulMatch, MatchFailureReport, matchPrefixSuccess} from "../MatchPrefixResult";
-import {MatchPrefixResult} from "../MatchPrefixResult";
+import { isSuccessfulMatch, MatchFailureReport, MatchPrefixResult, matchPrefixSuccess } from "../MatchPrefixResult";
 import { Microgrammar } from "../Microgrammar";
-import {  isSpecialMember, PatternMatch, TreePatternMatch } from "../PatternMatch";
+import { isSpecialMember, PatternMatch, TreePatternMatch } from "../PatternMatch";
 import { Literal, Regex } from "../Primitives";
 
 import { readyToMatch } from "../internal/Whitespace";

--- a/src/matchers/java/JavaBody.ts
+++ b/src/matchers/java/JavaBody.ts
@@ -1,6 +1,6 @@
 import { InputState } from "../../InputState";
 import { MatchingLogic } from "../../Matchers";
-import {MatchPrefixResult, matchPrefixSuccess, SuccessfulMatch} from "../../MatchPrefixResult";
+import { MatchPrefixResult, matchPrefixSuccess } from "../../MatchPrefixResult";
 import { TerminalPatternMatch } from "../../PatternMatch";
 import { Concat } from "../Concat";
 

--- a/src/matchers/java/JavaBody.ts
+++ b/src/matchers/java/JavaBody.ts
@@ -31,7 +31,7 @@ class JavaBody implements MatchingLogic {
         }
     }
 
-    public matchPrefix(is: InputState): MatchPrefixResult {
+    public matchPrefix(is: InputState, thisMatchContext, parseContext): MatchPrefixResult {
         const sm = new JavaContentStateMachine();
         let depth = 1;
         if (is.exhausted()) {
@@ -74,7 +74,7 @@ class JavaBody implements MatchingLogic {
         }
 
         // We supply the offset to preserve it in this match
-        return this.inner.matchPrefix(inputStateFromString(matched, is.offset));
+        return this.inner.matchPrefix(inputStateFromString(matched, is.offset), thisMatchContext, parseContext);
     }
 }
 

--- a/src/matchers/skip/Skip.ts
+++ b/src/matchers/skip/Skip.ts
@@ -30,11 +30,18 @@ export const RestOfInput: MatchingLogic = {
 export const RestOfLine: MatchingLogic = new Break("\n");
 
 /**
- * Match a string until the given logic. Wraps Break.
+ * Match a string until the given matcher. Wraps Break.
  * Binds the content until the break.
  */
 export function takeUntil(what): MatchingLogic {
     return new Break(what);
+}
+
+/**
+ * Skip all content until the given matcher. Bind its match
+ */
+export function skipTo(what): MatchingLogic {
+    return new Break(what, true);
 }
 
 /**

--- a/src/matchers/skip/Skip.ts
+++ b/src/matchers/skip/Skip.ts
@@ -6,7 +6,7 @@ import { MatchingLogic } from "../../Matchers";
 import { Break } from "../snobol/Break";
 
 import { InputState } from "../../InputState";
-import {matchPrefixSuccess} from "../../MatchPrefixResult";
+import { matchPrefixSuccess } from "../../MatchPrefixResult";
 import { TerminalPatternMatch } from "../../PatternMatch";
 
 /**

--- a/src/matchers/snobol/Break.ts
+++ b/src/matchers/snobol/Break.ts
@@ -28,15 +28,28 @@ export class Break implements MatchingLogic {
      * @param butNot pattern we don't want to see before the desired determinal match.
      * If we see this pattern before, the match breaks.
      */
-    constructor(private breakOn: any, private consume: boolean = false, butNot?: any) {
+    constructor(breakOn: any, private consume: boolean = false, butNot?: any) {
         this.terminateOn = toMatchingLogic(breakOn);
         if (butNot) {
             this.badMatcher = toMatchingLogic(butNot);
         }
     }
 
-    // tslint:disable-next-line:member-ordering
-    public $id = `Break[${this.breakOn}]`;
+    get $id() {
+        return `Break[${this.terminateOn}]`;
+    }
+
+    public canStartWith(char: string): boolean {
+        return (this.consume && !this.badMatcher && this.terminateOn.canStartWith) ?
+            this.terminateOn.canStartWith(char) :
+            true;
+    }
+
+    get requiredPrefix() {
+        return (this.consume && !this.badMatcher) ?
+            this.terminateOn.requiredPrefix :
+            undefined;
+    }
 
     public matchPrefix(is: InputState, thisMatchContext, parseContext): MatchPrefixResult {
         if (is.exhausted()) {

--- a/src/matchers/snobol/Break.ts
+++ b/src/matchers/snobol/Break.ts
@@ -38,25 +38,25 @@ export class Break implements MatchingLogic {
     // tslint:disable-next-line:member-ordering
     public $id = `Break[${this.breakOn}]`;
 
-    public matchPrefix(is: InputState): MatchPrefixResult {
+    public matchPrefix(is: InputState, thisMatchContext, parseContext): MatchPrefixResult {
         if (is.exhausted()) {
             return matchPrefixSuccess(new TerminalPatternMatch(this.$id, "", is.offset, is));
         }
 
         let currentIs = is;
         let matched = "";
-        let terminalMatch: MatchPrefixResult = this.terminateOn.matchPrefix(currentIs);
+        let terminalMatch: MatchPrefixResult = this.terminateOn.matchPrefix(currentIs, thisMatchContext, parseContext);
         while (!currentIs.exhausted() && !isSuccessfulMatch(terminalMatch)) { // if it fits, it sits
             // But we can't match the bad match if it's defined
             if (this.badMatcher) {
-                if (isSuccessfulMatch(this.badMatcher.matchPrefix(currentIs))) {
+                if (isSuccessfulMatch(this.badMatcher.matchPrefix(currentIs, thisMatchContext, parseContext))) {
                     return new MatchFailureReport(this.$id, is.offset);
                 }
             }
             matched += currentIs.peek(1);
             currentIs = currentIs.advance();
             if (!currentIs.exhausted()) {
-                terminalMatch = this.terminateOn.matchPrefix(currentIs);
+                terminalMatch = this.terminateOn.matchPrefix(currentIs, thisMatchContext, parseContext);
             }
         }
         // We have found the terminal if we get here

--- a/src/matchers/snobol/Break.ts
+++ b/src/matchers/snobol/Break.ts
@@ -1,8 +1,8 @@
-import {InputState} from "../../InputState";
-import {MatchingLogic} from "../../Matchers";
-import {isSuccessfulMatch, MatchFailureReport, MatchPrefixResult, matchPrefixSuccess} from "../../MatchPrefixResult";
-import {TerminalPatternMatch} from "../../PatternMatch";
-import {toMatchingLogic} from "../Concat";
+import { InputState } from "../../InputState";
+import { MatchingLogic } from "../../Matchers";
+import { isSuccessfulMatch, MatchFailureReport, MatchPrefixResult, matchPrefixSuccess } from "../../MatchPrefixResult";
+import { TerminalPatternMatch } from "../../PatternMatch";
+import { toMatchingLogic } from "../Concat";
 
 /**
  * Inspired by SNOBOL BREAK: http://www.snobol4.org/docs/burks/tutorial/ch4.htm

--- a/src/matchers/snobol/Span.ts
+++ b/src/matchers/snobol/Span.ts
@@ -1,6 +1,6 @@
 import { InputState } from "../../InputState";
 import { MatchingLogic } from "../../Matchers";
-import {MatchFailureReport, MatchPrefixResult, matchPrefixSuccess} from "../../MatchPrefixResult";
+import { MatchFailureReport, MatchPrefixResult, matchPrefixSuccess } from "../../MatchPrefixResult";
 import { TerminalPatternMatch } from "../../PatternMatch";
 
 /**

--- a/src/matchers/snobol/Span.ts
+++ b/src/matchers/snobol/Span.ts
@@ -15,7 +15,7 @@ export class Span implements MatchingLogic {
     constructor(public characters: string) {
     }
 
-    public matchPrefix(is: InputState): MatchPrefixResult {
+    public matchPrefix(is: InputState, thisMatchContext, parseContext): MatchPrefixResult {
         let currentIs = is;
         let matched = "";
         while (!currentIs.exhausted() && this.characters.indexOf(currentIs.peek(1)) > -1) {

--- a/test/AltTest.ts
+++ b/test/AltTest.ts
@@ -11,21 +11,21 @@ describe("Alt", () => {
     it("should not match when neither A or B matches", () => {
         const alt = new Alt("A", "B");
         const is = inputStateFromString("friday 14");
-        const m = alt.matchPrefix(is);
+        const m = alt.matchPrefix(is, {}, {});
         assert(!isSuccessfulMatch(m));
     });
 
     it("should not match when none of many matches", () => {
         const alt = new Alt("A", "B", "C", "D", "Cat");
         const is = inputStateFromString("friday 14");
-        const m = alt.matchPrefix(is);
+        const m = alt.matchPrefix(is, {}, {});
         assert(!isSuccessfulMatch(m));
     });
 
     it("should match when A matches", () => {
         const alt = new Alt("A", "B");
         const is = inputStateFromString("AB");
-        const m = alt.matchPrefix(is);
+        const m = alt.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -37,7 +37,7 @@ describe("Alt", () => {
     it("should match when B matches", () => {
         const alt = new Alt("A", "B");
         const is = inputStateFromString("BA");
-        const m = alt.matchPrefix(is);
+        const m = alt.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -49,7 +49,7 @@ describe("Alt", () => {
     it("should match when C matches", () => {
         const alt = new Alt("A", "B", "C");
         const is = inputStateFromString("CXY");
-        const m = alt.matchPrefix(is);
+        const m = alt.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             assert(m.$matched === "C");
         } else {
@@ -60,7 +60,7 @@ describe("Alt", () => {
     it("should match with 3 when early matcher matches", () => {
         const alt = new Alt("A", "B", "C");
         const is = inputStateFromString("AD");
-        const m = alt.matchPrefix(is);
+        const m = alt.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 

--- a/test/BooleanTest.ts
+++ b/test/BooleanTest.ts
@@ -1,7 +1,7 @@
 import { isSuccessfulMatch } from "../src/MatchPrefixResult";
 import assert = require("power-assert");
 import { inputStateFromString } from "../src/internal/InputStateFactory";
-import {  PatternMatch } from "../src/PatternMatch";
+import { PatternMatch } from "../src/PatternMatch";
 import { LowercaseBoolean } from "../src/Primitives";
 
 describe("LowercaseBoolean", () => {
@@ -9,24 +9,24 @@ describe("LowercaseBoolean", () => {
     it("matches true", () => {
         const pm = LowercaseBoolean.matchPrefix(inputStateFromString("true")) as PatternMatch;
         if (isSuccessfulMatch(pm)) {
-                       const mmmm = pm.match as any;
-                       assert(mmmm.$value);
+            const mmmm = pm.match as any;
+            assert(mmmm.$value);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("matches false", () => {
         const pm = LowercaseBoolean.matchPrefix(inputStateFromString("false")) as PatternMatch;
         if (isSuccessfulMatch(pm)) {
-                       const mmmm = pm.match as any;
-                       assert(!mmmm.$value);
+            const mmmm = pm.match as any;
+            assert(!mmmm.$value);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("doesn't match junk", () => {
         const pm = LowercaseBoolean.matchPrefix(inputStateFromString("xyz")) as PatternMatch;

--- a/test/ContextTest.ts
+++ b/test/ContextTest.ts
@@ -14,7 +14,7 @@ describe("ContextTest", () => {
             b: Integer,
             sum: ctx => ctx.a + ctx.b,
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}, {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
         assert(matched.sum === 24 + 7);
@@ -27,7 +27,7 @@ describe("ContextTest", () => {
             willBeFalse: ctx => typeof ctx.a === "string",
             sum: ctx => ctx.a + ctx.b,
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}, {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
         assert(matched.sum === 24 + 7);
@@ -39,7 +39,7 @@ describe("ContextTest", () => {
             b: Integer,
             sum: ctx => ctx.a + ctx.b,
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}, {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
         assert(matched.sum === 24 + 7);
@@ -53,7 +53,7 @@ describe("ContextTest", () => {
                 ctx.b = parseInt(ctx.b, 10);
             },
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}, {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
     });
@@ -64,7 +64,7 @@ describe("ContextTest", () => {
             stringB: /[0-9]+/,
             b: ctx => parseInt(ctx.stringB, 10),
         });
-        const matched: any = (cc.matchPrefix(inputStateFromString("24 7")) as SuccessfulMatch).match;
+        const matched: any = (cc.matchPrefix(inputStateFromString("24 7"), {}, {}) as SuccessfulMatch).match;
         assert(matched.a === 24);
         assert(matched.b === 7);
     });
@@ -78,9 +78,9 @@ describe("ContextTest", () => {
             b: Integer,
             c: Integer,
         });
-        const matched = cc.matchPrefix(inputStateFromString("true 7 35"));
+        const matched = cc.matchPrefix(inputStateFromString("true 7 35"), {}, {});
         assert(isSuccessfulMatch(matched));
-        const matched2 = cc.matchPrefix(inputStateFromString("false 7 35"));
+        const matched2 = cc.matchPrefix(inputStateFromString("false 7 35"), {}, {});
         assert(!isSuccessfulMatch(matched2));
     });
 
@@ -95,7 +95,7 @@ describe("ContextTest", () => {
             b: Integer,
             c: Integer,
         });
-        const matched = (cc.matchPrefix(inputStateFromString("gary 7 35")) as SuccessfulMatch).match;
+        const matched = (cc.matchPrefix(inputStateFromString("gary 7 35"), {}, {}) as SuccessfulMatch).match;
         assert((matched as any).promoted === "gary");
     });
 

--- a/test/ContextTest.ts
+++ b/test/ContextTest.ts
@@ -1,10 +1,10 @@
 import * as assert from "power-assert";
-import {inputStateFromString} from "../src/internal/InputStateFactory";
-import {Concat} from "../src/matchers/Concat";
-import {isSuccessfulMatch, SuccessfulMatch} from "../src/MatchPrefixResult";
-import {Microgrammar} from "../src/Microgrammar";
+import { inputStateFromString } from "../src/internal/InputStateFactory";
+import { Concat } from "../src/matchers/Concat";
+import { isSuccessfulMatch, SuccessfulMatch } from "../src/MatchPrefixResult";
+import { Microgrammar } from "../src/Microgrammar";
 
-import {Integer, LowercaseBoolean} from "../src/Primitives";
+import { Integer, LowercaseBoolean } from "../src/Primitives";
 
 describe("ContextTest", () => {
 

--- a/test/ExactMatchTest.ts
+++ b/test/ExactMatchTest.ts
@@ -1,0 +1,80 @@
+import "mocha";
+import { JavaParenthesizedExpression } from "../src/matchers/java/JavaBody";
+import { Microgrammar } from "../src/Microgrammar";
+import { isPatternMatch } from "../src/PatternMatch";
+import { JAVA_IDENTIFIER } from "./matchers/java/JavaBlockMicrogrammarTest";
+
+import * as assert from "power-assert";
+import { fail } from "power-assert";
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
+
+describe("Microgrammar.exactMatch", () => {
+
+    it("parse all content: File matches", () => {
+        const content = "public void thing(int i);";
+        const mg = Microgrammar.fromDefinitions<{ name: string }>({
+            _p: "public",
+            type: JAVA_IDENTIFIER,
+            name: JAVA_IDENTIFIER,
+            params: JavaParenthesizedExpression,
+            _semi: ";",
+        });
+        const result = mg.exactMatch(content);
+        if (isPatternMatch(result)) {
+            assert(result);
+            assert(result.$matched === content);
+            assert(result.name === "thing");
+        } else {
+            fail();
+        }
+    });
+
+    it("parse all content: pattern match recognized in output", () => {
+        const content = "public void";
+        const mg = Microgrammar.fromDefinitions<any>({
+            _p: "public",
+            type: JAVA_IDENTIFIER,
+        });
+        const result = mg.exactMatch(content);
+        assert(isPatternMatch(result));
+    });
+
+    it("parse all content: dismatch report recognized in output", () => {
+        const content = "not-matchy void";
+        const mg = Microgrammar.fromDefinitions<{ type: string }>({
+            _p: "public",
+            type: JAVA_IDENTIFIER,
+        });
+        const result = mg.exactMatch(content);
+        assert(!isPatternMatch(result));
+        if (!isPatternMatch(result)) {
+            assert(result.description !== undefined);
+        }
+    });
+
+    it("parse all content: Fail due to irrelevant content after match", () => {
+        const content = "public void thing(int i); // and this is irrelevant crap";
+        const mg = Microgrammar.fromDefinitions<any>({
+            _p: "public",
+            type: JAVA_IDENTIFIER,
+            name: JAVA_IDENTIFIER,
+            params: JavaParenthesizedExpression,
+            _semi: ";",
+        });
+        const result = mg.exactMatch(content);
+        assert(!isSuccessfulMatch(result));
+    });
+
+    it("parse all content: Fail due to irrelevant content before match", () => {
+        const content = "// and this is irrelevant crap\npublic void thing(int i);";
+        const mg = Microgrammar.fromDefinitions<any>({
+            _p: "public",
+            type: JAVA_IDENTIFIER,
+            name: JAVA_IDENTIFIER,
+            params: JavaParenthesizedExpression,
+            _semi: ";",
+        });
+        const result = mg.exactMatch(content);
+        assert(!isSuccessfulMatch(result));
+    });
+});

--- a/test/FloatTest.ts
+++ b/test/FloatTest.ts
@@ -1,8 +1,7 @@
-import {expect} from "chai";
-import {inputStateFromString} from "../src/internal/InputStateFactory";
-import {isSuccessfulMatch} from "../src/MatchPrefixResult";
-import {PatternMatch} from "../src/PatternMatch";
-import {Float} from "../src/Primitives";
+import { inputStateFromString } from "../src/internal/InputStateFactory";
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
+import { PatternMatch } from "../src/PatternMatch";
+import { Float } from "../src/Primitives";
 
 import * as assert from "power-assert";
 
@@ -14,9 +13,8 @@ describe("Float", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;
-            expect(match.$matched).to.equal("1");
-            expect(match.$value).to.equal(1.0);
-
+            assert(match.$matched === "1");
+            assert(match.$value === 1.0);
         } else {
             assert.fail("Didn't match");
         }
@@ -28,9 +26,8 @@ describe("Float", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;
-            expect(match.$matched).to.equal("105");
-            expect(match.$value).to.equal(105.0);
-
+            assert(match.$matched === "105");
+            assert(match.$value === 105.0);
         } else {
             assert.fail("Didn't match");
         }
@@ -42,9 +39,8 @@ describe("Float", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;
-            expect(match.$matched).to.equal("105.25555");
-            expect(match.$value).to.equal(105.25555);
-
+            assert(match.$matched === "105.25555");
+            assert(match.$value === 105.25555);
         } else {
             assert.fail("Didn't match");
         }
@@ -56,9 +52,8 @@ describe("Float", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;
-            expect(match.$matched).to.equal("-105.25555");
-            expect(match.$value).to.equal(-105.25555);
-
+            assert(match.$matched === "-105.25555");
+            assert(match.$value === -105.25555);
         } else {
             assert.fail("Didn't match");
         }
@@ -70,9 +65,8 @@ describe("Float", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             const match = mmmm as PatternMatch;
-            expect(match.$matched).to.equal("-.25555");
-            expect(match.$value).to.equal(-0.25555);
-
+            assert(match.$matched === "-.25555");
+            assert(match.$value === -0.25555);
         } else {
             assert.fail("Didn't match");
         }

--- a/test/IntegerTest.ts
+++ b/test/IntegerTest.ts
@@ -1,6 +1,5 @@
 import { inputStateFromString } from "../src/internal/InputStateFactory";
 import { isSuccessfulMatch } from "../src/MatchPrefixResult";
-import {  PatternMatch } from "../src/PatternMatch";
 import { Integer } from "../src/Primitives";
 
 import * as assert from "power-assert";
@@ -14,7 +13,7 @@ describe("Integer", () => {
     });
 
     it("should recognize invalid prefixes", () => {
-        for (const c of [ "-", "$", "a", "n", "*" ]) {
+        for (const c of ["-", "$", "a", "n", "*"]) {
             assert(!Integer.canStartWith(c));
         }
     });
@@ -26,28 +25,28 @@ describe("Integer matching", () => {
         const is = inputStateFromString("1");
         const m = Integer.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       const match = mmmm;
-                       assert(match.$matched === "1");
-                       assert(match.$value === 1);
+            const mmmm = m.match as any;
+            const match = mmmm;
+            assert(match.$matched === "1");
+            assert(match.$value === 1);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("test multiple digits", () => {
         const is = inputStateFromString("105x");
         const m = Integer.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       const match = mmmm;
-                       assert(match.$matched === "105");
-                       assert(match.$value === 105);
+            const mmmm = m.match as any;
+            const match = mmmm;
+            assert(match.$matched === "105");
+            assert(match.$value === 105);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
 });

--- a/test/MatchingMachineTest.ts
+++ b/test/MatchingMachineTest.ts
@@ -1,5 +1,4 @@
 import assert = require("power-assert");
-import { expect } from "chai";
 
 import { MatchingLogic } from "../src/Matchers";
 import { MatchingMachine } from "../src/Microgrammar";
@@ -38,7 +37,7 @@ describe("MatchingMachine", () => {
         const mm = new SaveEverySecondMatch();
         mm.consume(input);
         const result = mm.matches.map(m => m.$matched);
-        expect(result).to.deep.equals(["Nicolas", "Emmanuel"]);
+        assert.deepEqual(result, ["Nicolas", "Emmanuel"]);
     });
 
     it("save first word then numbers only", () => {
@@ -65,7 +64,7 @@ describe("MatchingMachine", () => {
         const mm = new SaveWordAndNumbers();
         mm.consume(input);
         const result = mm.matches.map(m => m.$matched);
-        expect(result).to.deep.equal(["Nicolas", "1234"]);
+        assert.deepEqual(result, ["Nicolas", "1234"]);
     });
 
     const pyClass = {

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -1,20 +1,19 @@
-import {expect} from "chai";
+import { expect } from "chai";
 import * as assert from "power-assert";
-import {MatchingLogic, Term} from "../src/Matchers";
-import {isSuccessfulMatch} from "../src/MatchPrefixResult";
-import {MatchingMachine, Microgrammar} from "../src/Microgrammar";
-import {Alt, Opt} from "../src/Ops";
-import {isPatternMatch, PatternMatch} from "../src/PatternMatch";
-import {Rep, Rep1Sep, RepSep} from "../src/Rep";
-import {RealWorldPom} from "./Fixtures";
+import { fail } from "power-assert";
+import { MatchingLogic, Term } from "../src/Matchers";
+import { MatchingMachine, Microgrammar } from "../src/Microgrammar";
+import { Alt, Opt } from "../src/Ops";
+import { isPatternMatch, PatternMatch } from "../src/PatternMatch";
+import { Rep, Rep1Sep, RepSep } from "../src/Rep";
+import { RealWorldPom } from "./Fixtures";
 import {
-    ALL_PLUGIN_GRAMMAR, ARTIFACT_VERSION_GRAMMAR, DEPENDENCY_GRAMMAR, PLUGIN_GRAMMAR,
+    ALL_PLUGIN_GRAMMAR,
+    ARTIFACT_VERSION_GRAMMAR,
+    DEPENDENCY_GRAMMAR,
+    PLUGIN_GRAMMAR,
     VersionedArtifact,
 } from "./MavenGrammars";
-
-import {fail} from "power-assert";
-import {JavaParenthesizedExpression} from "../src/matchers/java/JavaBody";
-import {JAVA_IDENTIFIER} from "./matchers/java/JavaBlockMicrogrammarTest";
 
 describe("Microgrammar", () => {
 
@@ -57,74 +56,6 @@ describe("Microgrammar", () => {
         } catch (e) {
             assert(e.toString().lastIndexOf("content") !== -1);
         }
-    });
-
-    it("parse all content: File matches", () => {
-        const content = "public void thing(int i);";
-        const mg = Microgrammar.fromDefinitions<{ name: string }>({
-            _p: "public",
-            type: JAVA_IDENTIFIER,
-            name: JAVA_IDENTIFIER,
-            params: JavaParenthesizedExpression,
-            _semi: ";",
-        });
-        const result = mg.exactMatch(content);
-        if (isPatternMatch(result)) {
-            assert(result);
-            assert(result.$matched === content);
-            assert(result.name === "thing");
-        } else {
-            fail();
-        }
-    });
-
-    it("parse all content: pattern match recognized in output", () => {
-        const content = "public void";
-        const mg = Microgrammar.fromDefinitions<any>({
-            _p: "public",
-            type: JAVA_IDENTIFIER,
-        });
-        const result = mg.exactMatch(content);
-        assert(isPatternMatch(result));
-    });
-
-    it("parse all content: dismatch report recognized in output", () => {
-        const content = "not-matchy void";
-        const mg = Microgrammar.fromDefinitions<{ type: string }>({
-            _p: "public",
-            type: JAVA_IDENTIFIER,
-        });
-        const result = mg.exactMatch(content);
-        assert(!isPatternMatch(result));
-        if (!isPatternMatch(result)) {
-            assert(result.description !== undefined);
-        }
-    });
-
-    it("parse all content: Fail due to irrelevant content after match", () => {
-        const content = "public void thing(int i); // and this is irrelevant crap";
-        const mg = Microgrammar.fromDefinitions<any>({
-            _p: "public",
-            type: JAVA_IDENTIFIER,
-            name: JAVA_IDENTIFIER,
-            params: JavaParenthesizedExpression,
-            _semi: ";",
-        });
-        const result = mg.exactMatch(content);
-        assert(!isSuccessfulMatch(result));
-    });
-
-    it("parse all content: Fail due to irrelevant content before match", () => {
-        const content = "// and this is irrelevant crap\npublic void thing(int i);";
-        const mg = Microgrammar.fromDefinitions<any>({
-            _p: "public",
-            type: JAVA_IDENTIFIER,
-            name: JAVA_IDENTIFIER,
-            params: JavaParenthesizedExpression,
-            _semi: ";",
-        });
-        const result = mg.exactMatch(content);
-        assert(!isSuccessfulMatch(result));
     });
 
     it("XML element", () => {

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -250,7 +250,7 @@ describe("Microgrammar", () => {
         expect(result.length).to.equal(2);
         expect(result[0].name).to.equal("Emmanuel");
         expect(result[1].name).to.equal("Marine");
-        const result2 = mg.findMatches("Greg Tony", pm => true);
+        const result2 = mg.findMatches("Greg Tony", {}, pm => true);
         expect(result2.length).to.equal(1);
         expect(result2[0].name).to.equal("Greg");
         const result3 = mg.firstMatch("Bill George");

--- a/test/MicrogrammarTest.ts
+++ b/test/MicrogrammarTest.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
-import * as assert from "power-assert";
 import { fail } from "power-assert";
+import * as assert from "power-assert";
+import { WhiteSpaceSensitive } from "../src/Config";
 import { MatchingLogic, Term } from "../src/Matchers";
 import { MatchingMachine, Microgrammar } from "../src/Microgrammar";
 import { Alt, Opt } from "../src/Ops";
@@ -41,8 +42,8 @@ describe("Microgrammar", () => {
         });
         const result = validMg.findMatches(content);
         // console.log("Result is " + JSON.stringify(result));
-        expect(result.length).to.equal(1);
-        expect(result[0].$matched).to.equal("foo");
+        assert(result.length === 1);
+        assert(result[0].$matched === "foo");
     });
 
     it("prevents invalid call to function", () => {
@@ -61,26 +62,24 @@ describe("Microgrammar", () => {
     it("XML element", () => {
         const content = "<foo>";
         const mg = Microgrammar.fromDefinitions({
-            $id: "elt",
             lx: "<",
             name: /[a-zA-Z0-9]+/,
             rx: ">",
         });
         const result = mg.findMatches(content);
         // console.log("Result is " + JSON.stringify(result));
-        expect(result.length).to.equal(1);
+        assert(result.length === 1);
         const r0 = result[0] as any;
-        expect(r0.name).to.equal("foo");
+        assert(r0.name === "foo");
         // expect(r0.matched).to.equal("<foo>")
     });
 
     function testTwoXmlElements(content: string, first: string, second: string) {
         const mg = Microgrammar.fromDefinitions({
-            $id: "elt",
-            lx: "<",
+            _lx: "<",
             name: /[a-zA-Z0-9]+/,
-            rx: ">",
-        } as Term);
+            _rx: ">",
+        });
         const result = mg.findMatches(content);
         // console.log("Result is " + JSON.stringify(result));
         expect(result.length).to.equal(2);
@@ -123,15 +122,15 @@ describe("Microgrammar", () => {
     it("2 XML elements via nested microgrammar", () => {
         const content = "<first><second>";
         const element = {
-            lx: "<",
+            _lx: "<",
             namex: /[a-zA-Z0-9]+/,
-            rx: ">",
+            _rx: ">",
         };
         const mg = Microgrammar.fromDefinitions({
             $id: "elt",
             first: element,
             second: element,
-        } as Term);
+        });
         const result = mg.findMatches(content);
         // console.log("xxx Result is " + JSON.stringify(result));
         expect(result.length).to.equal(1);
@@ -143,31 +142,26 @@ describe("Microgrammar", () => {
     it("2 elements: whitespace insensitive", () => {
         const content = "<first> notxml";
         const mg = Microgrammar.fromDefinitions({
-            $id: "element",
-            lx: "<",
+            _lx: "<",
             namex: /[a-zA-Z0-9]+/,
-            rx: ">",
+            _rx: ">",
             notxml: "notxml",
-        } as Term, {
-            consumeWhiteSpaceBetweenTokens: true,
         });
         const result = mg.findMatches(content);
-        expect(result.length).to.equal(1);
+        assert(result.length === 1);
     });
 
     it("2 elements: whitespace sensitive", () => {
         const content = "<first> notxml";
         const mg = Microgrammar.fromDefinitions({
-            $id: "elt",
-            lx: "<",
+            ...WhiteSpaceSensitive,
+            _lx: "<",
             namex: /[a-zA-Z0-9]+/,
-            rx: ">",
+            _rx: ">",
             notxml: "notxml",
-        } as Term, {
-            consumeWhiteSpaceBetweenTokens: false,
         });
         const result = mg.findMatches(content);
-        expect(result.length).to.equal(0);
+        assert(result.length === 0);
     });
 
     it("stop after match with arrow function", () => {
@@ -465,7 +459,7 @@ describe("Microgrammar", () => {
 class StringGrammar {
 
     public static readonly stringTextPattern =
-        new Rep(new Alt("\\\"", /[^"]/)).withConfig({consumeWhiteSpaceBetweenTokens: false}); // (?:\\"|[^"])*/;
+        new Rep(new Alt("\\\"", /[^"]/)); // (?:\\"|[^"])*/;
 
     public static readonly stringGrammar: Microgrammar<any> = Microgrammar.fromDefinitions<any>({
         foo: ctx => {
@@ -476,12 +470,10 @@ class StringGrammar {
             console.log("1");
         },
         charArray: StringGrammar.stringTextPattern,
-
         foo3: ctx => {
             console.log(`3 + [${JSON.stringify(ctx.charArray)})]`);
         },
         _p2: '"',
-
         foo4: ctx => {
             console.log("4");
         },

--- a/test/OptTest.ts
+++ b/test/OptTest.ts
@@ -1,11 +1,9 @@
-import {expect} from "chai";
-import {inputStateFromString} from "../src/internal/InputStateFactory";
-import {Term} from "../src/Matchers";
-import {isSuccessfulMatch} from "../src/MatchPrefixResult";
-import {Microgrammar} from "../src/Microgrammar";
-import {Opt} from "../src/Ops";
-import {PatternMatch} from "../src/PatternMatch";
-import {Literal} from "../src/Primitives";
+import { inputStateFromString } from "../src/internal/InputStateFactory";
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
+import { Microgrammar } from "../src/Microgrammar";
+import { Opt, optional } from "../src/Ops";
+import { PatternMatch } from "../src/PatternMatch";
+import { Literal } from "../src/Primitives";
 
 import * as assert from "power-assert";
 
@@ -14,10 +12,10 @@ describe("Opt", () => {
     it("should match when matcher doesn't match", () => {
         const alt = new Opt("A");
         const is = inputStateFromString("friday 14");
-        const m = alt.matchPrefix(is) as PatternMatch;
+        const m = alt.matchPrefix(is, {}, {}) as PatternMatch;
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
-            expect(mmmm.$value).to.equal(undefined);
+            assert(mmmm.$value === undefined);
 
         } else {
             assert.fail("Didn't match");
@@ -27,10 +25,10 @@ describe("Opt", () => {
     it("should match when matcher matches", () => {
         const alt = new Opt("A");
         const is = inputStateFromString("AB");
-        const m = alt.matchPrefix(is) as PatternMatch;
+        const m = alt.matchPrefix(is, {}, {}) as PatternMatch;
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
-            expect(mmmm.$value).to.equal("A");
+            assert(mmmm.$value === "A");
 
         } else {
             assert.fail("Didn't match");
@@ -41,53 +39,49 @@ describe("Opt", () => {
         const content = "";
         const mg = new Opt(new Literal("x"));
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as PatternMatch;
+        const result = mg.matchPrefix(is, {}, {}) as PatternMatch;
         // console.log(JSON.stringify(result));
-        expect(result.$matched).to.equal("");
+        assert(result.$matched === "");
     });
 
     it("test raw opt present", () => {
         const content = "x";
         const mg = new Opt(new Literal("x"));
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as PatternMatch;
+        const result = mg.matchPrefix(is, {}, {}) as PatternMatch;
         // console.log(JSON.stringify(result));
-        expect(result.$matched).to.equal("x");
+        assert(result.$matched === "x");
     });
 
     it("not pull up single property", () => {
         const content = "x";
         const nested = Microgrammar.fromDefinitions({
                 x: new Literal("x"),
-                $id: "xx",
-            } as Term,
+            },
         );
         const mg = Microgrammar.fromDefinitions({
-                x: new Opt(nested),
-                $id: "x",
-            } as Term,
+                x: optional(nested),
+            },
         );
 
         const result = mg.firstMatch(content) as any;
-        expect(result.x.x).to.equal("x");
+        assert(result.x.x === "x");
     });
 
     it("pull up single property", () => {
         const content = "x";
         const nested = Microgrammar.fromDefinitions({
                 x: new Literal("x"),
-                $id: "xx",
-            } as Term,
+            },
         );
         const mg = Microgrammar.fromDefinitions({
-                _x: new Opt(nested),
-            x: ctx => ctx._x.x,
-                $id: "x",
-            } as Term,
-        );
+            _x: optional(nested),
+            x: ctx => !!ctx._x ? ctx._x.x : undefined,
+        });
 
         const result = mg.firstMatch(content) as any;
-        expect(result.x).to.equal("x");
+        assert(result);
+        assert(result.x === "x");
     });
 
 });

--- a/test/PositioningTest.ts
+++ b/test/PositioningTest.ts
@@ -1,17 +1,10 @@
-import { Term } from "../src/Matchers";
 import { Microgrammar } from "../src/Microgrammar";
-import { PatternMatch } from "../src/PatternMatch";
 import { Rep } from "../src/Rep";
 import { ALL_DEPENDENCY_GRAMMAR, VersionedArtifact } from "./MavenGrammars";
 
 import assert = require("power-assert");
 
 describe("Positioning", () => {
-    // let subject: Calculator;
-    //
-    // beforeEach(() => {
-    //     subject = new Calculator();
-    // });
 
     describe("should get position of pattern", () => {
         it("should do it", () => {
@@ -29,7 +22,7 @@ const DEPENDENCY_MANAGEMENT_GRAMMAR =
         startElement: "<dependencyManagement>",
         _deps: "<dependencies>",
         dependencies: new Rep(ALL_DEPENDENCY_GRAMMAR),
-    } as Term);
+    });
 
 const PomWithDependencyManagement =
     `<?xml version="1.0" encoding="UTF-8"?>

--- a/test/RegexTest.ts
+++ b/test/RegexTest.ts
@@ -19,7 +19,6 @@ describe("Regex", () => {
             const match = mmmm;
             assert(match.$matched === "friday");
             assert(mmmm.$offset === 0);
-
         } else {
             assert.fail("Didn't match");
         }
@@ -33,7 +32,6 @@ describe("Regex", () => {
             const match = mmmm;
             assert(match.$matched === "friday");
             assert(mmmm.$offset === 0);
-
         } else {
             assert.fail("Didn't match");
         }
@@ -63,7 +61,6 @@ describe("Regex", () => {
         const withSkip = new Break(regexp, true);
         const m = withSkip.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-            const mmmm = m.match as any;
             const match = m as any as PatternMatch;
             assert(match.$matched === "**friday");
             assert(match.$offset === 2);

--- a/test/RegexTest.ts
+++ b/test/RegexTest.ts
@@ -2,7 +2,7 @@ import { inputStateFromString } from "../src/internal/InputStateFactory";
 import { isSuccessfulMatch } from "../src/MatchPrefixResult";
 
 import { Microgrammar } from "../src/Microgrammar";
-import {  PatternMatch } from "../src/PatternMatch";
+import { PatternMatch } from "../src/PatternMatch";
 import { Regex } from "../src/Primitives";
 
 import * as assert from "power-assert";
@@ -15,29 +15,29 @@ describe("Regex", () => {
         const is = inputStateFromString("friday 14");
         const m = regexp.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       const match = mmmm;
-                       assert(match.$matched === "friday");
-                       assert(mmmm.$offset === 0);
+            const mmmm = m.match as any;
+            const match = mmmm;
+            assert(match.$matched === "friday");
+            assert(mmmm.$offset === 0);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
     it("match word letters using anchor that will be recognized", () => {
         const regexp = new Regex(/[a-z]+/);
         const is = inputStateFromString("friday 14");
         const m = regexp.matchPrefix(is);
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       const match = mmmm;
-                       assert(match.$matched === "friday");
-                       assert(mmmm.$offset === 0);
+            const mmmm = m.match as any;
+            const match = mmmm;
+            assert(match.$matched === "friday");
+            assert(mmmm.$offset === 0);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("should add anchor if not present", () => {
         const regexp = new Regex(/[a-z]+/);
@@ -61,18 +61,18 @@ describe("Regex", () => {
         const regexp = new Regex(/[a-z]+/);
         const is = inputStateFromString("**friday 14");
         const withSkip = new Break(regexp, true);
-        const m = withSkip.matchPrefix(is);
+        const m = withSkip.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       const match = m as any as PatternMatch;
-                       assert(match.$matched === "**friday");
-                       assert(match.$offset === 2);
-                       assert(match.$value === "friday");
+            const mmmm = m.match as any;
+            const match = m as any as PatternMatch;
+            assert(match.$matched === "**friday");
+            assert(match.$offset === 2);
+            assert(match.$value === "friday");
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("matches regex length 20", () => matchRegexOfLength(20));
 
@@ -81,7 +81,7 @@ describe("Regex", () => {
     it("matches regex length 5000", () => matchRegexOfLength(5000));
 
     function matchRegexOfLength(n: number) {
-        const mg = Microgrammar.fromDefinitions<{r: string, other: string}>({
+        const mg = Microgrammar.fromDefinitions<{ r: string, other: string }>({
             r: /[a-z]+/,
             other: ".",
         });

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -15,7 +15,7 @@ describe("Rep", () => {
     it("rep(0) should match 0 when matcher doesn't match", () => {
         const rep = new Rep("A");
         const is = inputStateFromString("friday 14");
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        // expect(is.peek(2)).to.equal(mmmm.$resultingInputState.peek(2));
@@ -28,14 +28,14 @@ describe("Rep", () => {
     it("rep(1) should NOT match 0 when matcher doesn't match", () => {
         const rep = new Rep1("A");
         const is = inputStateFromString("friday 14");
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         assert(!isSuccessfulMatch(m));
     });
 
     it("should match when matcher matches once", () => {
         const rep = new Rep("A");
         const is = inputStateFromString("And there was light!");
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -47,7 +47,7 @@ describe("Rep", () => {
     it("repsep should match when matcher matches once", () => {
         const rep = new RepSep("A", "abcd");
         const is = inputStateFromString("And there was light!");
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -61,7 +61,7 @@ describe("Rep", () => {
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert((mmmm).$matched === toMatch);
@@ -76,7 +76,7 @@ describe("Rep", () => {
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert((mmmm).$matched === "And");
@@ -91,7 +91,7 @@ describe("Rep", () => {
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is) as PatternMatch;
+        const m = rep.matchPrefix(is, {}, {}) as PatternMatch;
         assert(m.$value.length === 4);
     });
 
@@ -100,7 +100,7 @@ describe("Rep", () => {
         const toMatch = "And,there,was,light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert((mmmm).$matched === toMatch);
@@ -115,7 +115,7 @@ describe("Rep", () => {
         const toMatch = "And,there,was,light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert((mmmm).$matched === toMatch);
@@ -130,7 +130,7 @@ describe("Rep", () => {
         const toMatch = "And";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
 
@@ -144,7 +144,7 @@ describe("Rep", () => {
         const toMatch = "16And";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);
-        const m = rep.matchPrefix(is);
+        const m = rep.matchPrefix(is, {}, {});
         assert(!isSuccessfulMatch(m));
     });
 
@@ -156,7 +156,7 @@ describe("Rep", () => {
 	</properties>
         `;
         const is = inputStateFromString(toMatch);
-        const m = rep.matchPrefix(is) as PatternMatch;
+        const m = rep.matchPrefix(is, {}, {}) as PatternMatch;
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$value.length === 3);

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -79,7 +79,7 @@ describe("Rep", () => {
     });
 
     it("rep does not match several times when not ignoring whitespace", () => {
-        const rep = new Rep(/[a-zA-Z]+/).withConfig({consumeWhiteSpaceBetweenTokens: false});
+        const rep = new Rep(/[a-zA-Z]+/).consumeWhiteSpace(false);
         const toMatch = "And there was light";
         const content = toMatch + "!"; // The last char won't match
         const is = inputStateFromString(content);

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -30,7 +30,6 @@ describe("Rep", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             // expect(is.peek(2)).to.equal(mmmm.$resultingInputState.peek(2));
-
         } else {
             assert.fail("Didn't match");
         }
@@ -49,7 +48,6 @@ describe("Rep", () => {
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
-
         } else {
             assert.fail("Didn't match");
         }
@@ -61,7 +59,6 @@ describe("Rep", () => {
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
-
         } else {
             assert.fail("Didn't match");
         }
@@ -76,7 +73,6 @@ describe("Rep", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === toMatch);
-
         } else {
             assert.fail("Didn't match");
         }
@@ -91,7 +87,6 @@ describe("Rep", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "And");
-
         } else {
             assert.fail("Didn't match");
         }
@@ -115,7 +110,6 @@ describe("Rep", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === toMatch);
-
         } else {
             assert.fail("Didn't match");
         }
@@ -130,7 +124,6 @@ describe("Rep", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === toMatch);
-
         } else {
             assert.fail("Didn't match");
         }
@@ -144,7 +137,6 @@ describe("Rep", () => {
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
-
         } else {
             assert.fail("Didn't match");
         }
@@ -171,7 +163,6 @@ describe("Rep", () => {
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert(mmmm.$value.length === 3);
-
         } else {
             assert.fail("Didn't match");
         }

--- a/test/RepTest.ts
+++ b/test/RepTest.ts
@@ -1,7 +1,7 @@
 import { inputStateFromString } from "../src/internal/InputStateFactory";
 import { isSuccessfulMatch } from "../src/MatchPrefixResult";
-import {  PatternMatch } from "../src/PatternMatch";
-import { Rep, Rep1, Rep1Sep, RepSep } from "../src/Rep";
+import { PatternMatch } from "../src/PatternMatch";
+import { atLeastOne, Rep, Rep1, Rep1Sep, RepSep, zeroOrMore } from "../src/Rep";
 import { LEGAL_VALUE } from "./MavenGrammars";
 
 import { Microgrammar } from "../src/Microgrammar";
@@ -9,21 +9,32 @@ import { Alt, Opt } from "../src/Ops";
 import { RealWorldPom } from "./Fixtures";
 
 import * as assert from "power-assert";
+import { Literal } from "../src/Primitives";
 
 describe("Rep", () => {
+
+    it("zeroOrMore is same as Rep", () => {
+        const m = new Literal("Thing");
+        assert.deepEqual(zeroOrMore(m), new Rep(m));
+    });
+
+    it("atLeastOne is same as Rep1", () => {
+        const m = new Literal("Thing");
+        assert.deepEqual(atLeastOne(m), new Rep1(m));
+    });
 
     it("rep(0) should match 0 when matcher doesn't match", () => {
         const rep = new Rep("A");
         const is = inputStateFromString("friday 14");
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       // expect(is.peek(2)).to.equal(mmmm.$resultingInputState.peek(2));
+            const mmmm = m.match as any;
+            // expect(is.peek(2)).to.equal(mmmm.$resultingInputState.peek(2));
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("rep(1) should NOT match 0 when matcher doesn't match", () => {
         const rep = new Rep1("A");
@@ -37,24 +48,24 @@ describe("Rep", () => {
         const is = inputStateFromString("And there was light!");
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
+            const mmmm = m.match as any;
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("repsep should match when matcher matches once", () => {
         const rep = new RepSep("A", "abcd");
         const is = inputStateFromString("And there was light!");
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
+            const mmmm = m.match as any;
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("rep matches several times", () => {
         const rep = new Rep(/[a-zA-Z]+/);
@@ -63,13 +74,13 @@ describe("Rep", () => {
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       assert((mmmm).$matched === toMatch);
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === toMatch);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("rep does not match several times when not ignoring whitespace", () => {
         const rep = new Rep(/[a-zA-Z]+/).withConfig({consumeWhiteSpaceBetweenTokens: false});
@@ -78,13 +89,13 @@ describe("Rep", () => {
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       assert((mmmm).$matched === "And");
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === "And");
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("can extract data after rep matches several times", () => {
         const rep = new Rep(/[a-zA-Z]+/);
@@ -102,13 +113,13 @@ describe("Rep", () => {
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       assert((mmmm).$matched === toMatch);
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === toMatch);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("rep1sep matches several times", () => {
         const rep = new Rep1Sep(/[a-zA-Z]+/, ",");
@@ -117,13 +128,13 @@ describe("Rep", () => {
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       assert((mmmm).$matched === toMatch);
+            const mmmm = m.match as any;
+            assert((mmmm).$matched === toMatch);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("rep1sep matches once", () => {
         const rep = new Rep1Sep(/[a-zA-Z]+/, ",");
@@ -132,12 +143,12 @@ describe("Rep", () => {
         const is = inputStateFromString(content);
         const m = rep.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
+            const mmmm = m.match as any;
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("rep1sep does not match zero times", () => {
         const rep = new Rep1Sep(/[a-zA-Z]+/, ",");
@@ -158,13 +169,13 @@ describe("Rep", () => {
         const is = inputStateFromString(toMatch);
         const m = rep.matchPrefix(is, {}, {}) as PatternMatch;
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       assert(mmmm.$value.length === 3);
+            const mmmm = m.match as any;
+            assert(mmmm.$value.length === 3);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("should not infinite loop on rep of opt", () => {
         const mgDependency = Microgrammar.fromDefinitions({
@@ -180,7 +191,10 @@ describe("Rep", () => {
         });
         assert.throws(
             () => mgDependency.firstMatch(RealWorldPom),
-            m => { assert(m.message.indexOf("empty string") !== -1); return true; });
+            m => {
+                assert(m.message.indexOf("empty string") !== -1);
+                return true;
+            });
     });
 
     it("should not infinite loop on rep of alt with opt", () => {
@@ -207,7 +221,10 @@ describe("Rep", () => {
         });
         assert.throws(
             () => mgDependency.firstMatch(RealWorldPom),
-            m => { assert(m.message.indexOf("empty string") !== -1); return true; });
+            m => {
+                assert(m.message.indexOf("empty string") !== -1);
+                return true;
+            });
     });
 
 });

--- a/test/StringGrammarTest.ts
+++ b/test/StringGrammarTest.ts
@@ -41,7 +41,7 @@ describe("StringGrammarTest", () => {
 class StringGrammar {
 
     public static readonly stringTextPattern = new Rep(new Alt("\\\"", /^[^"]/))
-        .withConfig({consumeWhiteSpaceBetweenTokens: false});
+        .consumeWhiteSpace(false);
 
     public static readonly stringGrammar: Microgrammar<any> =
         Microgrammar.fromDefinitions<any>({

--- a/test/StringGrammarTest.ts
+++ b/test/StringGrammarTest.ts
@@ -1,12 +1,12 @@
 import "mocha";
-import {inputStateFromString} from "../src/internal/InputStateFactory";
-import {Microgrammar} from "../src/Microgrammar";
-import {Alt} from "../src/Ops";
-import {isPatternMatch} from "../src/PatternMatch";
-import {Rep} from "../src/Rep";
+import { inputStateFromString } from "../src/internal/InputStateFactory";
+import { Microgrammar } from "../src/Microgrammar";
+import { Alt } from "../src/Ops";
+import { isPatternMatch } from "../src/PatternMatch";
+import { Rep } from "../src/Rep";
 
 import * as assert from "power-assert";
-import {isSuccessfulMatch} from "../src/MatchPrefixResult";
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
 
 describe("StringGrammarTest", () => {
 

--- a/test/StringGrammarTest.ts
+++ b/test/StringGrammarTest.ts
@@ -17,19 +17,13 @@ describe("StringGrammarTest", () => {
             findMatches('"    winter is coming " la la la');
         const match = strings[0];
         assert(isPatternMatch(match));
-
-        // for (const k in match) {
-        //     console.log(`[${k}]=${match[k]}`);
-        // }
-
-        console.log("The string is " + match.theString);
         assert(match.$matched === '"    winter is coming "');
         assert(match.theString.text, "    winter is coming");
     });
 
     it("not broken without concat", () => {
         const result = new Alt(StringGrammar.stringGrammar, "la").
-        matchPrefix(inputStateFromString('"    winter is coming " la la la'));
+        matchPrefix(inputStateFromString('"    winter is coming " la la la'), {}, {});
         if (isSuccessfulMatch(result)) {
             const match = result.match;
             if (isPatternMatch(match)) {

--- a/test/StringificationTest.ts
+++ b/test/StringificationTest.ts
@@ -3,7 +3,7 @@ import "mocha";
 import * as assert from "power-assert";
 import { Microgrammar } from "../src/Microgrammar";
 
-describe("stringification", () => {
+describe("stringification and matchedStructure", () => {
 
     it("can JSON stringify microgrammar result", () => {
         const content = "<foo>";

--- a/test/WhenTest.ts
+++ b/test/WhenTest.ts
@@ -1,9 +1,9 @@
-import {expect} from "chai";
-import {inputStateFromString} from "../src/internal/InputStateFactory";
-import {isSuccessfulMatch} from "../src/MatchPrefixResult";
-import {when} from "../src/Ops";
+import { expect } from "chai";
+import { inputStateFromString } from "../src/internal/InputStateFactory";
+import { isSuccessfulMatch } from "../src/MatchPrefixResult";
+import { when } from "../src/Ops";
 
-import {Literal} from "../src/Primitives";
+import { Literal } from "../src/Primitives";
 
 import * as assert from "power-assert";
 
@@ -51,7 +51,6 @@ describe("When", () => {
         const m = hatesFoo.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
-
         } else {
             assert.fail("Didn't match");
         }

--- a/test/WhenTest.ts
+++ b/test/WhenTest.ts
@@ -19,7 +19,7 @@ describe("When", () => {
         if (!matcher.matchPrefix) {
             throw new Error("Error: matcher.matchPrefix returned by when is undefined");
         }
-        const m = matcher.matchPrefix(is);
+        const m = matcher.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
 
@@ -32,7 +32,7 @@ describe("When", () => {
         const primitive = new Literal("foo");
         const is = inputStateFromString("foo bar");
         const matcher = when(primitive, pm => false);
-        const m = matcher.matchPrefix(is);
+        const m = matcher.matchPrefix(is, {}, {});
         expect(isSuccessfulMatch(m)).to.equal(false);
     });
 
@@ -40,7 +40,7 @@ describe("When", () => {
         const primitive = new Literal("foo");
         const is = inputStateFromString("foo bar");
         const hatesFoo = when(primitive, pm => pm.$matched.indexOf("foo") === -1);
-        const m = hatesFoo.matchPrefix(is);
+        const m = hatesFoo.matchPrefix(is, {}, {});
         expect(isSuccessfulMatch(m)).to.equal(false);
     });
 
@@ -48,7 +48,7 @@ describe("When", () => {
         const primitive = new RegExp(/[a-z]+/);
         const is = inputStateFromString("bar and this is a load of other stuff");
         const hatesFoo = when(primitive, pm => pm.$matched.indexOf("foo") === -1);
-        const m = hatesFoo.matchPrefix(is);
+        const m = hatesFoo.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
 
@@ -61,7 +61,7 @@ describe("When", () => {
         const primitive = new Literal("foo");
         const is = inputStateFromString("foo bar");
         const requiresFoo = when(primitive, pm => pm.$matched.indexOf("foo") !== -1);
-        const m = requiresFoo.matchPrefix(is);
+        const m = requiresFoo.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
 
@@ -74,7 +74,7 @@ describe("When", () => {
         const primitive = new Literal("foo");
         const is = inputStateFromString("bar");
         const requiresFoo = when(primitive, pm => pm.$matched.indexOf("foo") !== -1);
-        const m = requiresFoo.matchPrefix(is);
+        const m = requiresFoo.matchPrefix(is, {}, {});
         expect(isSuccessfulMatch(m)).to.equal(false);
     });
 

--- a/test/fromString/ElementsDefaultToNonGreedyAnyTest.ts
+++ b/test/fromString/ElementsDefaultToNonGreedyAnyTest.ts
@@ -1,7 +1,6 @@
-import {isSuccessfulMatch} from "../../src/MatchPrefixResult";
+import { Microgrammar } from "../../src/Microgrammar";
+import { isPatternMatch } from "../../src/PatternMatch";
 import assert = require("power-assert");
-import {Microgrammar} from "../../src/Microgrammar";
-import {isPatternMatch} from "../../src/PatternMatch";
 
 describe("Elements default to non-greedy any", () => {
 
@@ -25,7 +24,6 @@ describe("Elements default to non-greedy any", () => {
             const mmmm = result as any;
             assert(mmmm.fruit === "banana");
             assert(mmmm.drink === "juice");
-
         } else {
             assert.fail("Didn't match");
         }
@@ -47,24 +45,21 @@ describe("Elements default to non-greedy any", () => {
         if (isPatternMatch(result)) {
             const mmmm = result as any;
             assert(mmmm.fruit.trim() === "banana");
-
         } else {
             assert.fail("Didn't match");
         }
     });
 
-    it.skip("trims whitespace from the captured text",
-        () => {
-            const content = "->   banana   <- ";
-            const mg = Microgrammar.fromString("-> ${fruit} <-");
-            const result: any = mg.exactMatch(content);
-            if (isPatternMatch(result)) {
-                const mmmm = result as any;
-                assert(mmmm.fruit === "banana");
-
-            } else {
-                assert.fail("Didn't match");
-            }
-        });
+    it.skip("trims whitespace from the captured text", () => {
+        const content = "->   banana   <- ";
+        const mg = Microgrammar.fromString("-> ${fruit} <-");
+        const result: any = mg.exactMatch(content);
+        if (isPatternMatch(result)) {
+            const mmmm = result as any;
+            assert(mmmm.fruit === "banana");
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
 });

--- a/test/fromString/MicrogrammarFromStringTest.ts
+++ b/test/fromString/MicrogrammarFromStringTest.ts
@@ -1,11 +1,14 @@
 import { expect } from "chai";
 import { Microgrammar } from "../../src/Microgrammar";
 import { Opt } from "../../src/Ops";
-import {isPatternMatch, PatternMatch} from "../../src/PatternMatch";
+import { isPatternMatch } from "../../src/PatternMatch";
 import { RepSep } from "../../src/Rep";
 import { RealWorldPom } from "../Fixtures";
 import {
-    ALL_PLUGIN_GRAMMAR, ARTIFACT_VERSION_GRAMMAR, LEGAL_VALUE, PLUGIN_GRAMMAR,
+    ALL_PLUGIN_GRAMMAR,
+    ARTIFACT_VERSION_GRAMMAR,
+    LEGAL_VALUE,
+    PLUGIN_GRAMMAR,
     VersionedArtifact,
 } from "../MavenGrammars";
 

--- a/test/fromString/MicrogrammarFromStringTest.ts
+++ b/test/fromString/MicrogrammarFromStringTest.ts
@@ -13,6 +13,7 @@ import {
 } from "../MavenGrammars";
 
 import * as assert from "power-assert";
+import { WhiteSpaceSensitive } from "../../src/Config";
 
 describe("MicrogrammarFromString", () => {
 
@@ -101,8 +102,6 @@ describe("MicrogrammarFromString", () => {
         const content = "<first>notxml";
         const mg = Microgrammar.fromString<{ namex: string[] }>("<${namex}> notxml", {
             namex: /[a-zA-Z0-9]+/,
-        }, {
-            consumeWhiteSpaceBetweenTokens: true,
         });
         const result = mg.findMatches(content);
         expect(result.length).to.equal(1);
@@ -112,9 +111,8 @@ describe("MicrogrammarFromString", () => {
     it("2 elements: whitespace sensitive: match", () => {
         const content = "<first>  notxml";
         const mg = Microgrammar.fromString<{ namex: string[] }>("<${namex}> notxml", {
+            ...WhiteSpaceSensitive,
             namex: /[a-zA-Z0-9]+/,
-        }, {
-            consumeWhiteSpaceBetweenTokens: false,
         });
         const result = mg.findMatches(content);
         expect(result.length).to.equal(0);
@@ -123,9 +121,8 @@ describe("MicrogrammarFromString", () => {
     it("2 elements: whitespace sensitive: no match", () => {
         const content = "<first>  notxml";
         const mg = Microgrammar.fromString<{ namex: string[] }>("<${namex}> notxml", {
+            ...WhiteSpaceSensitive,
             namex: /[a-zA-Z0-9]+/,
-        }, {
-            consumeWhiteSpaceBetweenTokens: false,
         });
         const result = mg.findMatches(content);
         expect(result.length).to.equal(0);
@@ -135,8 +132,6 @@ describe("MicrogrammarFromString", () => {
         const content = "<first>\n\tnotxml";
         const mg = Microgrammar.fromString<{ namex: string[] }>("<${namex}>\n\tnotxml", {
             namex: /[a-zA-Z0-9]+/,
-        }, {
-            consumeWhiteSpaceBetweenTokens: false,
         });
         const result = mg.findMatches(content);
         expect(result.length).to.equal(1);

--- a/test/fromString/MicrogrammarFromStringTest.ts
+++ b/test/fromString/MicrogrammarFromStringTest.ts
@@ -150,7 +150,7 @@ describe("MicrogrammarFromString", () => {
         expect(result.length).to.equal(2);
         expect(result[0].name).to.equal("Greg");
         expect(result[1].name).to.equal("Tony");
-        const result2 = mg.findMatches("David Theresa", pm => true);
+        const result2 = mg.findMatches("David Theresa", {}, pm => true);
         expect(result2.length).to.equal(1);
         expect(result2[0].name).to.equal("David");
         const result3 = mg.firstMatch("Gough Malcolm");

--- a/test/integration/RealWorldTest2.ts
+++ b/test/integration/RealWorldTest2.ts
@@ -1,6 +1,5 @@
 import { JavaBlock, JavaParenthesizedExpression } from "../../src/matchers/java/JavaBody";
 import { isSuccessfulMatch } from "../../src/MatchPrefixResult";
-import { PatternMatch } from "../../src/PatternMatch";
 
 import { Microgrammar } from "../../src/Microgrammar";
 import { Opt } from "../../src/Ops";

--- a/test/integration/RealWorldTest2.ts
+++ b/test/integration/RealWorldTest2.ts
@@ -1,6 +1,6 @@
 import { JavaBlock, JavaParenthesizedExpression } from "../../src/matchers/java/JavaBody";
 import { isSuccessfulMatch } from "../../src/MatchPrefixResult";
-import {  PatternMatch } from "../../src/PatternMatch";
+import { PatternMatch } from "../../src/PatternMatch";
 
 import { Microgrammar } from "../../src/Microgrammar";
 import { Opt } from "../../src/Ops";
@@ -39,15 +39,15 @@ describe("GrammarWithOnlyARep", () => {
     it("can handle rep", () => {
         const rep = new Rep(AnyAnnotation);
         const src = `@ChangeControlled @Donkey("24", name = "Eeyore") public void magic() {}`;
-        const match = rep.matchPrefix(inputStateFromString(src)) as PatternMatch;
+        const match = rep.matchPrefix(inputStateFromString(src), {}, {});
         if (isSuccessfulMatch(match)) {
-                       const mmmm = match.match as any;
-                       assert(mmmm.$matched.trim() === `@ChangeControlled @Donkey("24", name = "Eeyore")`);
+            const mmmm = match.match as any;
+            assert(mmmm.$matched.trim() === `@ChangeControlled @Donkey("24", name = "Eeyore")`);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("match valid annotations with trailing junk", () => {
         const src = `@ChangeControlled @Donkey("24", name = "Eeyore")

--- a/test/internal/InputStateTest.ts
+++ b/test/internal/InputStateTest.ts
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 
 import { InputStream } from "../../src/spi/InputStream";
 import { DEPENDENCY_GRAMMAR } from "../MavenGrammars";
@@ -17,18 +16,18 @@ describe("InputState", () => {
 
     it("remainder is all", () => {
         const is = inputStateFromString("foo bar");
-        expect(is.peek(10)).equals("foo bar");
+        assert(is.peek(10) === "foo bar");
     });
 
     it("remainder is correct after advance", () => {
         const is = inputStateFromString("foo bar").advance();
         // expect(is.content).equals("foo bar");
-        expect(is.peek(1000)).equals("oo bar");
+        assert(is.peek(1000) === "oo bar");
     });
 
     it("remainder is correct after attempt advance past end", () => {
         const is = inputStateFromString("f").advance();
-        expect(is.peek(10)).equals("");
+        assert(is.peek(10) === "");
     });
 
     it("peek is correct after read", () => {
@@ -82,14 +81,14 @@ describe("InputState", () => {
 
     it("read ahead does not dirty parent", () => {
         const stream = new ReleasingStringInputStream("the quick brown fox jumps over the lazy dog");
-        expect(stream.offset).to.equal(0);
+        assert(stream.offset === 0);
         const state0 = inputStateFromStream(stream);
         const state1 = state0.advance();
-        expect(state1.offset).to.equal(1);
+        assert(state1.offset === 1);
         const state2 = state1.advance();
         const state3 = state2.advance().advance();
-        expect(state3.consume("quick").peek(" brown".length)).to.equal(" brown");
-        expect(state0.offset).to.equal(0);
+        assert(state3.consume("quick").peek(" brown".length) === " brown");
+        assert(state0.offset === 0);
         // This isn't valid as this state is stale
         // expect(state0.peek("the quick brown".length)).to.equal("the quick brown");
     });
@@ -135,7 +134,7 @@ describe("InputState", () => {
         for (const s of [easyMatch, requiresBacktracking, requiresMoreBacktracking]) {
             const input = new ReleasingStringInputStream(s);
             const pm = complexGrammar.firstMatch(input);
-            expect(pm.version).to.equal("0.1.1");
+            assert(pm.version === "0.1.1");
         }
     });
 

--- a/test/internal/UpdaterTests.ts
+++ b/test/internal/UpdaterTests.ts
@@ -1,6 +1,6 @@
 import assert = require("power-assert");
 
-import {Microgrammar} from "../../src/Microgrammar";
+import { Microgrammar } from "../../src/Microgrammar";
 
 function XmlElement() {
     return Microgrammar.fromString("<${name}>", {

--- a/test/matchers/ConcatTest.ts
+++ b/test/matchers/ConcatTest.ts
@@ -16,7 +16,7 @@ describe("Concat", () => {
             name: "foo",
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is);
+        const result = mg.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(result)) {
             expect((result.match as any).name).to.equal("foo");
             assert(result.$matched === "foo");
@@ -32,7 +32,7 @@ describe("Concat", () => {
             num: /[1-9][0-9]*/,
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as any;
+        const result = mg.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(result)) {
             const mmm = result.match as any;
             assert(mmm.$matched === content);
@@ -46,7 +46,7 @@ describe("Concat", () => {
             num: Integer,
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as any;
+        const result = mg.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             // expect(mmmm.$matched).to.equal(content);
@@ -67,7 +67,7 @@ describe("Concat", () => {
             num: Integer,
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as any;
+        const result = mg.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             expect(mmmm.$matched).to.equal(content);
@@ -86,7 +86,7 @@ describe("Concat", () => {
             days: Integer,
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as any;
+        const result = mg.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             expect(mmmm.$matched).to.equal(content);
@@ -108,7 +108,7 @@ describe("Concat", () => {
         });
         const content = "Lizzy+Katrina";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as any;
+        const result = mg.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.name === "Lizzy");
@@ -129,7 +129,7 @@ describe("Concat", () => {
         });
         const content = "Lizzy+Katrina,Terri";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as any;
+        const result = mg.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.names[0], "Lizzy");
@@ -152,7 +152,7 @@ describe("Concat", () => {
         });
         const content = "Jardine vs Bradman,Woodfull";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as any;
+        const result = mg.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.gentlemen.names[0], "Jardine");
@@ -172,7 +172,7 @@ describe("Concat", () => {
         });
         const content = "Jardine vs Bradman,Woodfull";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as any;
+        const result = mg.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.gentlemen[0], "Jardine");
@@ -200,7 +200,7 @@ describe("Concat", () => {
         });
         const content = "Jardine(bat),Wyatt(bat) vs Bradman(bat,bowl),Woodfull(bat,keep)";
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as any;
+        const result = mg.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             assert(mmmm.gentlemen.names[0].name, "Jardine");
@@ -224,7 +224,7 @@ describe("Concat", () => {
             hobbies: new RepSep(/[a-z]+/, ","),
         });
         const is = inputStateFromString(content);
-        const result = mg.matchPrefix(is) as PatternMatch;
+        const result = mg.matchPrefix(is, {}, {}) as PatternMatch;
         if (isSuccessfulMatch(result)) {
             const mmmm = result.match as any;
             const r = mmmm as any;

--- a/test/matchers/java/JavaBlockTest.ts
+++ b/test/matchers/java/JavaBlockTest.ts
@@ -3,13 +3,11 @@ import { Microgrammar } from "../../../src/Microgrammar";
 import { PatternMatch } from "../../../src/PatternMatch";
 import { Regex } from "../../../src/Primitives";
 
-import { Break } from "../../../src/matchers/snobol/Break";
-
 import { inputStateFromString } from "../../../src/internal/InputStateFactory";
 
 import * as assert from "power-assert";
-import { isSuccessfulMatch } from "../../../src/MatchPrefixResult";
 import { RestOfInput } from "../../../src/matchers/skip/Skip";
+import { isSuccessfulMatch } from "../../../src/MatchPrefixResult";
 
 describe("JavaBlock", () => {
 

--- a/test/matchers/java/JavaBlockTest.ts
+++ b/test/matchers/java/JavaBlockTest.ts
@@ -1,7 +1,6 @@
-
 import { JavaBlock, javaBlockContaining } from "../../../src/matchers/java/JavaBody";
 import { Microgrammar } from "../../../src/Microgrammar";
-import {  PatternMatch } from "../../../src/PatternMatch";
+import { PatternMatch } from "../../../src/PatternMatch";
 import { Regex } from "../../../src/Primitives";
 
 import { Break } from "../../../src/matchers/snobol/Break";
@@ -9,7 +8,8 @@ import { Break } from "../../../src/matchers/snobol/Break";
 import { inputStateFromString } from "../../../src/internal/InputStateFactory";
 
 import * as assert from "power-assert";
-import {isSuccessfulMatch} from "../../../src/MatchPrefixResult";
+import { isSuccessfulMatch } from "../../../src/MatchPrefixResult";
+import { RestOfInput } from "../../../src/matchers/skip/Skip";
 
 describe("JavaBlock", () => {
 
@@ -46,23 +46,20 @@ describe("JavaBlock", () => {
         shouldNotMatch("{  ");
     });
 
-    // TODO need to implement this
-    it("should ignore { in multiline comments", () => {
-        // console.log("TODO: ignore { in multiline comments")
-    });
+    it("should ignore { in multiline comments");
 
     it("should match till balance", () => {
         const balanced = "{  x = y; { }  2; }";
         const is = inputStateFromString(balanced + "// this is a comment }");
         const m = JavaBlock.matchPrefix(is, {}, {}) as PatternMatch;
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       assert(mmmm.$matched === balanced);
+            const mmmm = m.match as any;
+            assert(mmmm.$matched === balanced);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     it("should match inner structure", () => {
         const balanced = "{ x = y; }";
@@ -71,33 +68,32 @@ describe("JavaBlock", () => {
             left: new Regex(/[a-z]+/),
             equals: "=",
             right: "y",
-            _whatever: new Break("//////"),
+            _whatever: RestOfInput,
         });
         const m: any = javaBlockContaining(inner.matcher).matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       assert(mmmm.$matched === balanced);
-                       assert(mmmm.block.left === "x");
-                       assert(mmmm.block.$valueMatches.left.$offset === 2);
-                       assert(mmmm.block.right === "y");
-                       assert(mmmm.block.$valueMatches.right.$offset === 6);
+            const mmmm = m.match as any;
+            assert(mmmm.$matched === balanced);
+            assert(mmmm.block.left === "x");
+            assert(mmmm.block.$valueMatches.left.$offset === 2);
+            assert(mmmm.block.right === "y");
+            assert(mmmm.block.$valueMatches.right.$offset === 6);
 
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   });
+        } else {
+            assert.fail("Didn't match");
+        }
+    });
 
     function match(what: string) {
         const is = inputStateFromString(what);
         const m = JavaBlock.matchPrefix(is, {}, {}) as PatternMatch;
         if (isSuccessfulMatch(m)) {
-                       const mmmm = m.match as any;
-                       assert(mmmm.$matched === what);
-
-                    } else {
-                       assert.fail("Didn't match");
-                    }
-                   }
+            const mmmm = m.match as any;
+            assert(mmmm.$matched === what);
+        } else {
+            assert.fail("Didn't match");
+        }
+    }
 
     function shouldNotMatch(what: string) {
         const is = inputStateFromString(what);

--- a/test/matchers/java/JavaBlockTest.ts
+++ b/test/matchers/java/JavaBlockTest.ts
@@ -54,7 +54,7 @@ describe("JavaBlock", () => {
     it("should match till balance", () => {
         const balanced = "{  x = y; { }  2; }";
         const is = inputStateFromString(balanced + "// this is a comment }");
-        const m = JavaBlock.matchPrefix(is) as PatternMatch;
+        const m = JavaBlock.matchPrefix(is, {}, {}) as PatternMatch;
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$matched === balanced);
@@ -73,7 +73,7 @@ describe("JavaBlock", () => {
             right: "y",
             _whatever: new Break("//////"),
         });
-        const m: any = javaBlockContaining(inner.matcher).matchPrefix(is);
+        const m: any = javaBlockContaining(inner.matcher).matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$matched === balanced);
@@ -89,7 +89,7 @@ describe("JavaBlock", () => {
 
     function match(what: string) {
         const is = inputStateFromString(what);
-        const m = JavaBlock.matchPrefix(is) as PatternMatch;
+        const m = JavaBlock.matchPrefix(is, {}, {}) as PatternMatch;
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$matched === what);
@@ -101,7 +101,7 @@ describe("JavaBlock", () => {
 
     function shouldNotMatch(what: string) {
         const is = inputStateFromString(what);
-        const m = JavaBlock.matchPrefix(is);
+        const m = JavaBlock.matchPrefix(is, {}, {});
         assert(!isSuccessfulMatch(m));
     }
 

--- a/test/matchers/skip/SkipTest.ts
+++ b/test/matchers/skip/SkipTest.ts
@@ -29,13 +29,13 @@ describe("Skip", () => {
 
     it("rest of line to end of line", () => {
         const input = "The quick brown\nfox jumps over\nthe lazy dog";
-        const pm = RestOfLine.matchPrefix(inputStateFromString(input));
+        const pm = RestOfLine.matchPrefix(inputStateFromString(input), {}, {});
         assert(isSuccessfulMatch(pm) && pm.$matched === "The quick brown");
     });
 
     it("rest of line consumes remaining input", () => {
         const input = "The quick brown fox jumps over the lazy dog";
-        const pm = RestOfLine.matchPrefix(inputStateFromString(input));
+        const pm = RestOfLine.matchPrefix(inputStateFromString(input), {}, {});
         assert(isSuccessfulMatch(pm) && pm.$matched === input);
     });
 

--- a/test/matchers/snobol/BreakTest.ts
+++ b/test/matchers/snobol/BreakTest.ts
@@ -1,16 +1,16 @@
-import {Term} from "../../../src/Matchers";
-import {Concat} from "../../../src/matchers/Concat";
-import {PatternMatch} from "../../../src/PatternMatch";
+import { Concat } from "../../../src/matchers/Concat";
+import { PatternMatch } from "../../../src/PatternMatch";
 import { Integer, Regex } from "../../../src/Primitives";
 
-import {Break} from "../../../src/matchers/snobol/Break";
+import { Break } from "../../../src/matchers/snobol/Break";
 
-import {inputStateFromString} from "../../../src/internal/InputStateFactory";
-import {Span} from "../../../src/matchers/snobol/Span";
-import {Alt} from "../../../src/Ops";
+import { inputStateFromString } from "../../../src/internal/InputStateFactory";
+import { Span } from "../../../src/matchers/snobol/Span";
+import { Alt } from "../../../src/Ops";
 
 import * as assert from "power-assert";
-import {isSuccessfulMatch} from "../../../src/MatchPrefixResult";
+import { WhiteSpaceSensitive } from "../../../src/Config";
+import { isSuccessfulMatch } from "../../../src/MatchPrefixResult";
 
 describe("Break", () => {
 
@@ -42,14 +42,17 @@ describe("Break", () => {
 
     it("break matches a complicated matcher", () => {
         const b = new Break(
-            new Concat({$id: "yeah", _start: "${", name: new Regex(/[a-z]+/), _end: "}"} as Term,
-                {consumeWhiteSpaceBetweenTokens: false}));
+            new Concat({
+                ...WhiteSpaceSensitive,
+                _start: "${",
+                name: new Regex(/[a-z]+/),
+                _end: "}",
+            }));
         const is = inputStateFromString("HEY YOU ${thing} and more stuff");
         const m = b.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "HEY YOU ");
-
         } else {
             assert.fail("Didn't match");
         }

--- a/test/matchers/snobol/BreakTest.ts
+++ b/test/matchers/snobol/BreakTest.ts
@@ -17,7 +17,7 @@ describe("Break", () => {
     it("break matches exhausted", () => {
         const b = new Break("14");
         const is = inputStateFromString("");
-        const m = b.matchPrefix(is);
+        const m = b.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "");
@@ -30,7 +30,7 @@ describe("Break", () => {
     it("break matches another matcher", () => {
         const b = new Break(new Regex(/[a-z]/));
         const is = inputStateFromString("HEY YOU banana");
-        const m = b.matchPrefix(is);
+        const m = b.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "HEY YOU ");
@@ -45,7 +45,7 @@ describe("Break", () => {
             new Concat({$id: "yeah", _start: "${", name: new Regex(/[a-z]+/), _end: "}"} as Term,
                 {consumeWhiteSpaceBetweenTokens: false}));
         const is = inputStateFromString("HEY YOU ${thing} and more stuff");
-        const m = b.matchPrefix(is);
+        const m = b.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "HEY YOU ");
@@ -58,7 +58,7 @@ describe("Break", () => {
     it("break matches", () => {
         const b = new Break("14");
         const is = inputStateFromString("friday 14");
-        const m = b.matchPrefix(is);
+        const m = b.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "friday ");
@@ -71,12 +71,12 @@ describe("Break", () => {
     it("break to Alt", () => {
         const b = new Break(new Alt("14", "44"));
         const is = inputStateFromString("friday 14");
-        const m = b.matchPrefix(is);
+        const m = b.matchPrefix(is, {}, {});
         assert(isSuccessfulMatch(m));
         assert((m as PatternMatch).$matched === "friday ");
 
         const is2 = inputStateFromString("friday 44");
-        const m2 = b.matchPrefix(is2);
+        const m2 = b.matchPrefix(is2, {}, {});
         assert(isSuccessfulMatch(m2));
         assert((m2 as PatternMatch).$matched === "friday ");
     });
@@ -84,7 +84,7 @@ describe("Break", () => {
     it("break matches and consumes", () => {
         const b = new Break("14", true);
         const is = inputStateFromString("friday 14");
-        const m = b.matchPrefix(is) as any;
+        const m = b.matchPrefix(is, {}, {}) as any;
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert(mmmm.$matched === "friday 14");
@@ -98,7 +98,7 @@ describe("Break", () => {
     it("break and consume uses value", () => {
         const b = new Break(Integer, true);
         const is = inputStateFromString("friday 14");
-        const m = b.matchPrefix(is) as any;
+        const m = b.matchPrefix(is, {}, {}) as any;
         assert(isSuccessfulMatch(m));
         assert(m.$matched === "friday 14");
         assert(m.$value === 14);
@@ -107,7 +107,7 @@ describe("Break", () => {
     it("break matches nothing as it comes immediately", () => {
         const b = new Break("friday");
         const is = inputStateFromString("friday 14");
-        const m = b.matchPrefix(is);
+        const m = b.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "");
@@ -124,7 +124,7 @@ describe("Break", () => {
             number: new Span("41"),
         });
         const is = inputStateFromString("friday 14");
-        const m = c.matchPrefix(is);
+        const m = c.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
             const mmmm = m.match as any;
             assert((mmmm).$matched === "friday 14");

--- a/test/matchers/snobol/SpanTest.ts
+++ b/test/matchers/snobol/SpanTest.ts
@@ -10,14 +10,14 @@ describe("Span", () => {
     it("span no match when no single char", () => {
         const span = new Span("abcd");
         const is = inputStateFromString("friday 14");
-        const m = span.matchPrefix(is);
+        const m = span.matchPrefix(is, {}, {});
         assert(!isSuccessfulMatch(m));
     });
 
     it("span match when first char matches", () => {
         const span = new Span("abcdef");
         const is = inputStateFromString("friday 14");
-        const m = span.matchPrefix(is);
+        const m = span.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$offset === 0);
@@ -31,7 +31,7 @@ describe("Span", () => {
     it("span match when some characters match", () => {
         const span = new Span("rabcdefi1");
         const is = inputStateFromString("friday 14");
-        const m = span.matchPrefix(is);
+        const m = span.matchPrefix(is, {}, {});
         if (isSuccessfulMatch(m)) {
                        const mmmm = m.match as any;
                        assert(mmmm.$offset === 0);

--- a/test/spi/TieredContextTest.ts
+++ b/test/spi/TieredContextTest.ts
@@ -51,7 +51,7 @@ describe("Per match context", () => {
     it("should be available within nested object and communicate back", () => {
         const mg = Microgrammar.fromDefinitions<{ name: string, zip: string }>({
             name: /[A-Z][a-z]+/,
-            _add: (_, matchContext) => matchContext.something = "magic",
+            _addToMatchContext: (_, matchContext) => matchContext.something = "magic",
             address: {
                 zip: skipTo(/[0-9]{5}/),
                 _verify: (_, matchContext) => {
@@ -66,10 +66,7 @@ describe("Per match context", () => {
         });
 
         const input = "Sandy:12345, Candice,94131   Terri:12345 Ahmed:64321";
-        const glob = {
-            zips: [],
-        };
-        const matches = mg.findMatches(input, glob);
+        const matches = mg.findMatches(input);
         assert(matches.length === 4);
     });
 

--- a/test/spi/TieredContextTest.ts
+++ b/test/spi/TieredContextTest.ts
@@ -1,0 +1,76 @@
+import "mocha";
+import { Microgrammar } from "../../src/Microgrammar";
+
+import { skipTo } from "../../src/matchers/skip/Skip";
+
+import * as assert from "power-assert";
+
+describe("Per file context", () => {
+
+    it("should be available within concat object", () => {
+        const mg = Microgrammar.fromDefinitions<{ name: string, zip: string }>({
+            name: /[A-Z][a-z]+/,
+            zip: skipTo(/[0-9]{5}/),
+            // Suppress duplicate if we're already seen this zip
+            _dedup: (ctx, _, parseContext) => {
+                if (parseContext.zips.indexOf(ctx.zip) === -1) {
+                    parseContext.zips.push(ctx.zip);
+                    return true;
+                }
+                return false;
+            },
+        });
+
+        const input = "Sandy:12345, Candice,94131   Terri:12345 Ahmed:64321";
+        const glob = {
+            zips: [],
+        };
+        const matches = mg.findMatches(input, glob);
+        assert(matches.length === 3);
+    });
+
+    it("should take only even matches", () => {
+        const mg = Microgrammar.fromDefinitions<{ name: string, zip: string }>({
+            name: /[A-Z][a-z]+/,
+            zip: skipTo(/[0-9]{5}/),
+            _keep: (ctx, _, parseContext) => ++parseContext.count % 2 === 0,
+        });
+
+        const input = "Sandy:12345, Candice,94131   Terri:12345 Ahmed:64321";
+        const glob = {
+            count: 0,
+        };
+        const matches = mg.findMatches(input, glob);
+        assert(matches.length === 2);
+    });
+
+});
+
+describe("Per match context", () => {
+
+    it("should be available within nested object and communicate back", () => {
+        const mg = Microgrammar.fromDefinitions<{ name: string, zip: string }>({
+            name: /[A-Z][a-z]+/,
+            _add: (_, matchContext) => matchContext.something = "magic",
+            address: {
+                zip: skipTo(/[0-9]{5}/),
+                _verify: (_, matchContext) => {
+                    assert(matchContext.something === "magic");
+                    assert(matchContext.andNowForSomethingCompleteDifferent === undefined, "This context must be fresh");
+                    matchContext.andNowForSomethingCompleteDifferent = true;
+                },
+            },
+            _verify: (_, matchContext) => {
+                assert(matchContext.andNowForSomethingCompleteDifferent === true);
+            },
+        });
+
+        const input = "Sandy:12345, Candice,94131   Terri:12345 Ahmed:64321";
+        const glob = {
+            zips: [],
+        };
+        const matches = mg.findMatches(input, glob);
+        assert(matches.length === 4);
+    });
+
+});

--- a/tslint.json
+++ b/tslint.json
@@ -15,7 +15,8 @@
         ],
         "max-classes-per-file": false,
         "object-literal-sort-keys": false,
-        "no-console": false
+        "no-console": false,
+        "max-line-length": [true, 140]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Introduced contexts for entire parsing operation (e.g. parsing a file using a microgrammar) and for the current match, however nested. These context parameters are available in concat definition literals. They can be ignored by matchers that don't need them, like Literal

These contexts are distinct from the context used during evaluation of a match, which is essentially a private working space when a match is unavailable.

Also overhauls context handling. Context parameters are now simply properties on a definitions object that will become a `Concat`. This does away with the problem of propagating and is very flexible. `Rep` objects explicitly take such a parameter. This will also allow new config properties to be added easily. Note the use of spreads to avoid the risk of misspelling a property.

**Acts on #16, not `master`.**

Other notes:

- Introduces 2 convenience functions for working with reps
- Moves some tests out of `MicrogrammarTest` into their own file. No tests have been removed.