### PR TITLE
Add clarity to the parts of a TreePatternMatch

### DIFF
--- a/src/Rep.ts
+++ b/src/Rep.ts
@@ -2,7 +2,7 @@ import { InputState } from "./InputState";
 import { MatchingLogic } from "./Matchers";
 import { toMatchingLogic } from "./matchers/Concat";
 import { isSuccessfulMatch, MatchFailureReport, MatchPrefixResult, matchPrefixSuccess } from "./MatchPrefixResult";
-import { PatternMatch, TerminalPatternMatch } from "./PatternMatch";
+import { ArrayPatternMatch, PatternMatch, TerminalPatternMatch } from "./PatternMatch";
 
 import { WhiteSpaceHandler } from "./Config";
 import { readyToMatch } from "./internal/Whitespace";
@@ -117,10 +117,10 @@ export class Repetition implements MatchingLogic, WhiteSpaceHandler {
         );
 
         return (matches.length >= this.min) ?
-            matchPrefixSuccess(new TerminalPatternMatch(this.$id,
+            matchPrefixSuccess(new ArrayPatternMatch(this.$id,
                 matched,
                 is.offset,
-                values)) :
+                matches)) :
             new MatchFailureReport(this.$id, is.offset, {});
     }
 }

--- a/src/internal/MicrogrammarUpdates.ts
+++ b/src/internal/MicrogrammarUpdates.ts
@@ -73,21 +73,20 @@ export class MicrogrammarUpdates {
                         enumerable: true,
                         configurable: true,
                     });
-                }
-                else if (isComputedThing(p)) {
+                } else if (isComputedThing(p)) {
                     // updates are not supported
                     Object.defineProperty(target, p.name, {
                         get() {
                             return p.value;
                         },
                         set(newValue) {
-                            throw new Error(`${p.name} was computed in a function in the microgrammar; you can't update it`)
+                            throw new Error(`${p.name} was computed in a function in the microgrammar; you can't update it`);
                         },
                         enumerable: true,
                         configurable: true,
                     });
                 } else {
-                    throw new Error("a new case has been added and it is not supported by update yet: " + p.kind)
+                    throw new Error("a new case has been added and it is not supported by update yet: " + p.kind);
                 }
 
             }

--- a/test/ContextTest.ts
+++ b/test/ContextTest.ts
@@ -89,8 +89,8 @@ describe("ContextTest", () => {
             nested: {
                 name: /[a-z]+/,
             },
-            promote(ctx) {
-                ctx.promoted = ctx.nested.name;
+            promoted(ctx) {
+                return ctx.nested.name;
             },
             b: Integer,
             c: Integer,

--- a/test/fromString/NestingTest.ts
+++ b/test/fromString/NestingTest.ts
@@ -17,8 +17,8 @@ describe("Nesting in Microgrammar.fromString", () => {
         const result = mg.findMatches(content) as any[];
         assert(result.length === 1);
         assert(result[0].catStatement.length === 2);
-        assert(result[0].catStatement[0].bug = "fleas");
-        assert(result[0].catStatement[1].bug = "worms");
+        assert(result[0].catStatement[0].bug === "fleas");
+        assert(result[0].catStatement[1].bug === "worms");
     });
 
     it("uses dictionary in nested sentences", () => {
@@ -34,8 +34,8 @@ describe("Nesting in Microgrammar.fromString", () => {
         const result = mg.findMatches(content) as any[];
         assert(result.length === 1);
         assert(result[0].catProblems.length === 2);
-        assert(result[0].catProblems[0].bug = "fleas");
-        assert(result[0].catProblems[1].bug = "worms");
+        assert(result[0].catProblems[0].bug === "fleas");
+        assert(result[0].catProblems[1].bug === "worms");
         assert.deepEqual(result[0].catActivities, ["grooming", "playing"]);
     });
 

--- a/test/integration/RealWorldTest2.ts
+++ b/test/integration/RealWorldTest2.ts
@@ -94,13 +94,15 @@ export interface RawAnnotation {
 
 export const ChangeControlledMethodGrammar = Microgrammar.fromDefinitions<ChangeControlledMethod>({
     annotations: new Rep1(AnyAnnotation),
-    _check(ctx: any) {
+    changeControlledAnnotation(ctx: any) {
         const found = ctx.annotations.filter(a => a.name === "ChangeControlled");
         if (found.length === 0) {
-            return false;
+            return undefined;
         }
-        ctx.changeControlledAnnotation = found;
-        return true;
+        return found;
+    },
+    _check(ctx: any) {
+        return (ctx.changeControlledAnnotation !== undefined);
     },
     _visibilityModifier: "public",
     type: JAVA_IDENTIFIER,

--- a/test/internal/MicrogrammarUpdateTest.ts
+++ b/test/internal/MicrogrammarUpdateTest.ts
@@ -1,12 +1,14 @@
-import {ChangeSet} from "../../src/internal/ChangeSet";
-import {isSuccessfulMatch} from "../../src/MatchPrefixResult";
-import {Microgrammar} from "../../src/Microgrammar";
-import {Opt} from "../../src/Ops";
+import { ChangeSet } from "../../src/internal/ChangeSet";
+import { isSuccessfulMatch } from "../../src/MatchPrefixResult";
+import { Microgrammar } from "../../src/Microgrammar";
+import { Opt } from "../../src/Ops";
 
 import * as assert from "power-assert";
 
-import {Integer} from "../../src/Primitives";
-import {RepSep} from "../../src/Rep";
+import { Integer } from "../../src/Primitives";
+import { RepSep } from "../../src/Rep";
+import { POM_WITH_DEPENDENCY_MANAGEMENT } from "../MatchingMachineTest";
+import { PARENT_STANZA } from "./mavenGrammars";
 
 describe("MicrogrammarUpdateTest", () => {
 
@@ -190,6 +192,17 @@ describe("MicrogrammarUpdateTest", () => {
         } else {
             assert.fail("Didn't match");
         }
+    });
+
+    it("update and validate properties", () => {
+        const results = PARENT_STANZA.findMatches(POM_WITH_DEPENDENCY_MANAGEMENT) as any;
+        assert(results.length === 1);
+        assert(results[0].gav, "gav non-null");
+        const updatable = Microgrammar.updatable<any>(results, POM_WITH_DEPENDENCY_MANAGEMENT);
+        assert(updatable.matches[0].gav, "gav still non-null");
+        // can't update it though
+        assert.throws(() => {updatable.matches[0].gav = "can't update a function output"});
+        assert(updatable.matches[0].gav.artifact === "spring-boot-starter-parent");
     });
 
 });

--- a/test/internal/MicrogrammarUpdateTest.ts
+++ b/test/internal/MicrogrammarUpdateTest.ts
@@ -201,7 +201,7 @@ describe("MicrogrammarUpdateTest", () => {
         const updatable = Microgrammar.updatable<any>(results, POM_WITH_DEPENDENCY_MANAGEMENT);
         assert(updatable.matches[0].gav, "gav still non-null");
         // can't update it though
-        assert.throws(() => {updatable.matches[0].gav = "can't update a function output"});
+        assert.throws(() => updatable.matches[0].gav = "can't update a function output");
         assert(updatable.matches[0].gav.artifact === "spring-boot-starter-parent");
     });
 

--- a/test/internal/mavenGrammars.ts
+++ b/test/internal/mavenGrammars.ts
@@ -1,0 +1,52 @@
+/**
+ * Test grammars
+ */
+
+import { Microgrammar } from "../../src/Microgrammar";
+import { atLeastOne } from "../../src/Rep";
+
+export const ELEMENT_NAME = /^[a-zA-Z_.0-9\-]+/;
+
+export const ELEMENT_CONTENT = /^[a-zA-Z_.0-9\-]+/;
+
+export const XML_TAG_WITH_SIMPLE_VALUE = {
+    _l: "<",
+    name: ELEMENT_NAME,
+    _r: ">",
+    value: ELEMENT_CONTENT,
+    _l2: "</",
+    _close: ELEMENT_NAME,
+    _ok: ctx => ctx._close === ctx.name,
+    _r2: ">",
+};
+
+export interface XmlTag {
+    name: string;
+    value: string;
+}
+
+export interface VersionedArtifact {
+    group: string;
+    artifact: string;
+    version?: string;
+}
+
+export const GAV_GRAMMAR = Microgrammar.fromDefinitions<{ gav: VersionedArtifact }>({
+    tags: atLeastOne(XML_TAG_WITH_SIMPLE_VALUE),
+    _valid: ctx =>
+        ctx.tags.filter(t => t.name === "groupId").length > 0 &&
+        ctx.tags.filter(t => t.name === "artifactId").length > 0,
+    gav: ctx => {
+        const group = ctx.tags.filter(tag => tag.name === "groupId")[0].value;
+        const artifact = ctx.tags.filter(tag => tag.name === "artifactId")[0].value;
+        const versions = ctx.tags.filter(tag => tag.name === "version");
+        const version = versions.length === 1 ? versions[0].value : undefined;
+        return { group, artifact, version };
+    },
+});
+
+export const PARENT_STANZA = Microgrammar.fromDefinitions<{ gav: VersionedArtifact }>({
+    _start: "<parent>",
+    _gav: GAV_GRAMMAR,
+    gav: ctx => ctx._gav.gav,
+});


### PR DESCRIPTION
Rod: this needs some of your naming magic. I called things "Thing"
in order that we can come back and name them. They're components
of a tree pattern match.

Main goal: clarify exactly what sort of things make up a TreePatternMatch.
There are scalars, nested trees, and computed properties.
These Things group the value and the pattern match for a property with its name.
Previously these were scattered across the values themselves (nested trees),
$valueMatches (scalars) and nowhere (arrays).

I added an ArrayPatternMatch for Rep to return, so that it can exhibit the $value as previously, and still contain the inner pattern matches even for scalars. This opens the possibility of allowing updates on things in arrays (although that's going to be hard and we need to talk it through).

$thingsInside is a public field only for the Updater stuff to use it.

The components described by the three kinds of Things can be updated inside computations, which I don't like, but it's supported. They retain their original value in a field just on principle. Nested structures don't support updates; we could add that, but it would not have worked before, I don't think, so I made it throw an error.

There is one **BREAKING CHANGE** which is: computations can't add arbitrary stuff to the context. They can only return values which get added to the context as the property defined by the function.
I strongly believe that this is a positive change. It's simpler: properties are all defined in definitions, not in sneaky functions ("Where did this come from??"). Everything that was done is still possible, with a bit of rearranging (see ContextTest and RealWorldTest2). If you do try to add a property to the context, you get an error; it doesn't throw it away silently.

Other things:
   - added $kind to TreePatternMatch for nicer typeguards
   - fixed accidental assignment in NestingTest, which came back as an error in the
 new structure how convenient
   - this fixes the update bug that Rod originally reported, that got me looking at it. I even made it handle computed fields specially so they provide a nice error message like "Error: gav was computed in a function in the microgrammar; you can't update it" (see "update and validate properties" in MicrogrammarUpdateTest)