### PR TITLE
Receive build notifications via Atomist

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -58,3 +58,19 @@ editor:
   artifact: "microgrammar"
   version: "0.1.0"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddTravisWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.68"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs.git"
+    branch: "1ef47a3059e4fbb20326ff4365c4ef7f06502165"
+    sha: "1ef47a3"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook-staging.atomist.services/atomist/travis/teams/T6MFSUPDL"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ notifications:
   webhooks:
     urls:
     - 'https://webhook.atomist.com/travis'
-    - >-
-        https://webhook-staging.atomist.services/atomist/travis/teams/T6MFSUPDL/undefined
+    - 'https://webhook-staging.atomist.services/atomist/travis/teams/T6MFSUPDL'
     on_success: always
     on_failure: always
     on_start: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ notifications:
   email: false
   webhooks:
     urls:
-    - https://webhook.atomist.com/travis
+    - 'https://webhook.atomist.com/travis'
+    - >-
+        https://webhook-staging.atomist.services/atomist/travis/teams/T6MFSUPDL/undefined
     on_success: always
     on_failure: always
     on_start: always


### PR DESCRIPTION
Send build events to Atomist.

They'll be incorporated into GitHub push and PR notifications,
so you'll see dynamically updated build results along with your commits.
Look for them in this channel in Slack.

[Travis webhook documentation](https://docs.travis-ci.com/user/notifications/#Configuring-webhook-notifications)