### PR TITLE
Avoid a class with private fields in an externally used type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ export * from "./lib/InputState";
 
 export * from "./lib/Matchers";
 
-export { Concat } from "./lib/matchers/Concat";
+export { Concat } from "./lib/matchers/Concat"; // Using this can cause extraneous type errors. Prefer MatchingLogic (an interface)
 
 export { flatten } from "./lib/matchers/Functions";
 

--- a/lib/Microgrammar.ts
+++ b/lib/Microgrammar.ts
@@ -10,6 +10,7 @@ import {
     Concat,
     TermDef,
     toMatchingLogic,
+    ConcatEnough,
 } from "./matchers/Concat";
 import { isSuccessfulMatch } from "./MatchPrefixResult";
 import {
@@ -90,7 +91,7 @@ export class Microgrammar<T> implements Term {
      * @return {Updatable<T>}
      */
     public static updatable<T>(matches: Array<T & PatternMatch>,
-                               content: string): Updatable<T> {
+        content: string): Updatable<T> {
         return new Updatable<T>(matches, content);
     }
 
@@ -125,8 +126,8 @@ export class Microgrammar<T> implements Term {
      * @return {Microgrammar<T>}
      */
     public static fromString<T = any>(spec: string,
-                                      components: TermsDefinition<T> = {} as any,
-                                      options: FromStringOptions = {}): Microgrammar<T> {
+        components: TermsDefinition<T> = {} as any,
+        options: FromStringOptions = {}): Microgrammar<T> {
         return new Microgrammar<T>(
             new MicrogrammarSpecParser().fromString(spec, components, options));
     }
@@ -141,17 +142,14 @@ export class Microgrammar<T> implements Term {
      * @return {Microgrammar<T>}
      */
     public static fromStringAs<T = any>(spec: string,
-                                        components: TermsDefinition<T> = {} as any,
-                                        options: FromStringOptions = {}): Microgrammar<AnyKeysOf<T>> {
+        components: TermsDefinition<T> = {} as any,
+        options: FromStringOptions = {}): Microgrammar<AnyKeysOf<T>> {
         return this.fromString(spec, components, options);
     }
 
     public readonly $id: string;
 
     public readonly definitions = this.matcher.definitions;
-
-    constructor(public readonly matcher: Concat) {
-    }
 
     /**
      * Generator for matching the given input.
@@ -164,6 +162,9 @@ export class Microgrammar<T> implements Term {
         return matchesIn(this, input, parseContext, l);
     }
 
+    constructor(public matcher: ConcatEnough) {
+    }
+
     /**
      * Convenience method to find matches without the ability to update them
      * @param input
@@ -174,9 +175,9 @@ export class Microgrammar<T> implements Term {
      * @return {PatternMatch[]}
      */
     public findMatches(input: string | InputStream,
-                       parseContext?: {},
-                       l?: Listeners,
-                       stopAfterMatch: (pm: PatternMatch) => boolean = () => false): Array<T & PatternMatch> {
+        parseContext?: {},
+        l?: Listeners,
+        stopAfterMatch: (pm: PatternMatch) => boolean = () => false): Array<T & PatternMatch> {
         const lm = new LazyMatcher(this.matcher, stopAfterMatch);
         lm.consume(input, parseContext, l);
         return lm.matches as Array<T & PatternMatch>;
@@ -189,7 +190,7 @@ export class Microgrammar<T> implements Term {
      * @return {Promise<Array<T & PatternMatch>>}
      */
     public async findMatchesAsync(input: string | InputStream,
-                                  parseContext?: {}): Promise<Array<T & PatternMatch>> {
+        parseContext?: {}): Promise<Array<T & PatternMatch>> {
         const matches = [];
         for (const m of matchesIn(this.matcher, input, parseContext)) {
             matches.push(m);

--- a/lib/Microgrammar.ts
+++ b/lib/Microgrammar.ts
@@ -8,9 +8,9 @@ import {
 } from "./Matchers";
 import {
     Concat,
+    Concatenation,
     TermDef,
     toMatchingLogic,
-    Concatenation,
 } from "./matchers/Concat";
 import { isSuccessfulMatch } from "./MatchPrefixResult";
 import {
@@ -91,7 +91,7 @@ export class Microgrammar<T> implements Term {
      * @return {Updatable<T>}
      */
     public static updatable<T>(matches: Array<T & PatternMatch>,
-        content: string): Updatable<T> {
+                               content: string): Updatable<T> {
         return new Updatable<T>(matches, content);
     }
 
@@ -126,8 +126,8 @@ export class Microgrammar<T> implements Term {
      * @return {Microgrammar<T>}
      */
     public static fromString<T = any>(spec: string,
-        components: TermsDefinition<T> = {} as any,
-        options: FromStringOptions = {}): Microgrammar<T> {
+                                      components: TermsDefinition<T> = {} as any,
+                                      options: FromStringOptions = {}): Microgrammar<T> {
         return new Microgrammar<T>(
             new MicrogrammarSpecParser().fromString(spec, components, options));
     }
@@ -175,9 +175,9 @@ export class Microgrammar<T> implements Term {
      * @return {PatternMatch[]}
      */
     public findMatches(input: string | InputStream,
-        parseContext?: {},
-        l?: Listeners,
-        stopAfterMatch: (pm: PatternMatch) => boolean = () => false): Array<T & PatternMatch> {
+                       parseContext?: {},
+                       l?: Listeners,
+                       stopAfterMatch: (pm: PatternMatch) => boolean = () => false): Array<T & PatternMatch> {
         const lm = new LazyMatcher(this.matcher, stopAfterMatch);
         lm.consume(input, parseContext, l);
         return lm.matches as Array<T & PatternMatch>;
@@ -190,7 +190,7 @@ export class Microgrammar<T> implements Term {
      * @return {Promise<Array<T & PatternMatch>>}
      */
     public async findMatchesAsync(input: string | InputStream,
-        parseContext?: {}): Promise<Array<T & PatternMatch>> {
+                                  parseContext?: {}): Promise<Array<T & PatternMatch>> {
         const matches = [];
         for (const m of matchesIn(this.matcher, input, parseContext)) {
             matches.push(m);

--- a/lib/Microgrammar.ts
+++ b/lib/Microgrammar.ts
@@ -10,7 +10,7 @@ import {
     Concat,
     TermDef,
     toMatchingLogic,
-    ConcatEnough,
+    Concatenation,
 } from "./matchers/Concat";
 import { isSuccessfulMatch } from "./MatchPrefixResult";
 import {
@@ -162,7 +162,7 @@ export class Microgrammar<T> implements Term {
         return matchesIn(this, input, parseContext, l);
     }
 
-    constructor(public matcher: ConcatEnough) {
+    constructor(public matcher: Concatenation) {
     }
 
     /**

--- a/lib/matchers/Concat.ts
+++ b/lib/matchers/Concat.ts
@@ -57,7 +57,11 @@ export type MatchStep = Matcher | MatchVeto | ContextComputation;
 const methodsOnEveryMatchingLogic = ["$id", "matchPrefix", "canStartWith", "requiredPrefix"];
 
 export type ConcatDefinitions = any; // maybe we can tighten this. For now, giving it a name
-export interface ConcatEnough extends MatchingLogic {
+
+/**
+ * The externally useful interface of Concat.
+ */
+export interface Concatenation extends MatchingLogic {
 
     definitions: ConcatDefinitions;
 
@@ -71,7 +75,7 @@ export interface ConcatEnough extends MatchingLogic {
  * Users should only create Concats directly in the unusual case where they need
  * to control whitespace handling in a unique way for that particular Concat.
  */
-export class Concat implements ConcatEnough, LazyMatchingLogic, WhiteSpaceHandler, SkipCapable {
+export class Concat implements Concatenation, LazyMatchingLogic, WhiteSpaceHandler, SkipCapable {
 
     /**
      * Normal way to create a Concat. If a $lazy field

--- a/lib/matchers/Concat.ts
+++ b/lib/matchers/Concat.ts
@@ -56,6 +56,13 @@ export type MatchStep = Matcher | MatchVeto | ContextComputation;
 
 const methodsOnEveryMatchingLogic = ["$id", "matchPrefix", "canStartWith", "requiredPrefix"];
 
+export type ConcatDefinitions = any; // maybe we can tighten this. For now, giving it a name
+export interface ConcatEnough extends MatchingLogic {
+
+    definitions: ConcatDefinitions;
+
+}
+
 /**
  * Represents a concatenation of multiple matchers. This is the normal
  * way we compose matches, although this class needn't be used explicitly,
@@ -64,7 +71,7 @@ const methodsOnEveryMatchingLogic = ["$id", "matchPrefix", "canStartWith", "requ
  * Users should only create Concats directly in the unusual case where they need
  * to control whitespace handling in a unique way for that particular Concat.
  */
-export class Concat implements LazyMatchingLogic, WhiteSpaceHandler, SkipCapable {
+export class Concat implements ConcatEnough, LazyMatchingLogic, WhiteSpaceHandler, SkipCapable {
 
     /**
      * Normal way to create a Concat. If a $lazy field

--- a/lib/matchers/lang/cfamily/CBlock.ts
+++ b/lib/matchers/lang/cfamily/CBlock.ts
@@ -23,8 +23,8 @@ export class CBlock implements MatchingLogic {
     private readonly pop: string;
 
     constructor(private readonly stateMachineFactory: () => LangStateMachine,
-        kind: "block" | "parens",
-        private readonly inner?: MatchingLogic) {
+                kind: "block" | "parens",
+                private readonly inner?: MatchingLogic) {
         switch (kind) {
             case "block":
                 [this.push, this.pop] = ["{", "}"];
@@ -89,7 +89,7 @@ export function block(stateMachineFactory: () => LangStateMachine) {
 }
 
 export function blockContaining(m: MatchingLogic,
-    stateMachineFactory: () => LangStateMachine = () => new CFamilyStateMachine()) {
+                                stateMachineFactory: () => LangStateMachine = () => new CFamilyStateMachine()) {
     return Concat.of({
         $id: "{...}",
         _lp: "{",

--- a/lib/matchers/lang/cfamily/CBlock.ts
+++ b/lib/matchers/lang/cfamily/CBlock.ts
@@ -23,8 +23,8 @@ export class CBlock implements MatchingLogic {
     private readonly pop: string;
 
     constructor(private readonly stateMachineFactory: () => LangStateMachine,
-                kind: "block" | "parens",
-                private readonly inner?: MatchingLogic) {
+        kind: "block" | "parens",
+        private readonly inner?: MatchingLogic) {
         switch (kind) {
             case "block":
                 [this.push, this.pop] = ["{", "}"];
@@ -88,8 +88,8 @@ export function block(stateMachineFactory: () => LangStateMachine) {
     });
 }
 
-export function blockContaining(m: Concat,
-                                stateMachineFactory: () => LangStateMachine = () => new CFamilyStateMachine()) {
+export function blockContaining(m: MatchingLogic,
+    stateMachineFactory: () => LangStateMachine = () => new CFamilyStateMachine()) {
     return Concat.of({
         $id: "{...}",
         _lp: "{",

--- a/lib/matchers/lang/cfamily/java/JavaBody.ts
+++ b/lib/matchers/lang/cfamily/java/JavaBody.ts
@@ -1,10 +1,10 @@
-import { Concat } from "../../../Concat";
 import {
     block,
     blockContaining,
     parenthesizedExpression,
 } from "../CBlock";
 import { CFamilyStateMachine } from "../CFamilyStateMachine";
+import { MatchingLogic } from "../../../..";
 
 /**
  * Match a Java block with balanced curlies
@@ -12,7 +12,7 @@ import { CFamilyStateMachine } from "../CFamilyStateMachine";
  */
 export const JavaBlock = block(() => new CFamilyStateMachine());
 
-export function javaBlockContaining(m: Concat) {
+export function javaBlockContaining(m: MatchingLogic) {
     return blockContaining(m);
 }
 

--- a/lib/matchers/lang/cfamily/java/JavaBody.ts
+++ b/lib/matchers/lang/cfamily/java/JavaBody.ts
@@ -1,10 +1,10 @@
+import { MatchingLogic } from "../../../..";
 import {
     block,
     blockContaining,
     parenthesizedExpression,
 } from "../CBlock";
 import { CFamilyStateMachine } from "../CFamilyStateMachine";
-import { MatchingLogic } from "../../../..";
 
 /**
  * Match a Java block with balanced curlies


### PR DESCRIPTION
Concat has private fields. Microgrammar declares a member of type Concat.
Some functions accept Microgrammar as an argument. This causes type errors
in SDMs when microgrammar versions are inconsistent between the SDM and
its dependencies like automation-client.

If we use an interface instead of the class type, these type errors will not
trouble us.