### PR TITLE
Introduce a way of creating a microgrammar depending only on an interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ if (match) {
 Here's a simple example:
 
 ```typescript
-const mg = Microgrammar.fromDefinitions<{name: string, age: number}>({
+const mg = microgrammar<{name: string, age: number}>({
     name: /[a-zA-Z0-9]+/,
     _col: ":",
     age: Integer
@@ -133,7 +133,7 @@ const DiscardedAnnotation = {
     _content: optional(JavaParenthesizedExpression),
 };
 
-const SpringBootApp = Microgrammar.fromDefinitions<{ name: string }>({
+const SpringBootApp = microgrammar<{ name: string }>({
     _app: "@SpringBootApplication",
     _content: optional(JavaParenthesizedExpression),
     _otherAnnotations: zeroOrMore(DiscardedAnnotation),
@@ -175,8 +175,8 @@ grammar.
 This style is ideally suited for simpler grammars. For example:
 
 ```typescript
-const ValuePredicateGrammar = Microgrammar.fromString<Predicate>(
-    "@${name}='${value}'");
+const ValuePredicateGrammar = microgrammar<Predicate>({
+    phrase: "@${name}='${value}'"});
 ```
 
 It can be combined with the definitional style through providing
@@ -184,10 +184,12 @@ optional definitions for the named fields. For example, to constrain
 the match on a name in the above example using a regular expression:
 
 ```typescript
-const ValuePredicateGrammar = Microgrammar.fromString<Predicate>(
-    "@${name}='${value}'", {
+const ValuePredicateGrammar = microgrammar<Predicate>({
+    phrase: "@${name}='${value}'", 
+    terms: {
     	name: /[a-z]+/
-    });
+    }
+});
 ```
 
 As with the object definitional style, whitespace is ignored by default.

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -7,10 +7,10 @@ Often
 A common pattern is to match a property with a `_` prefix--which causes the property not to be bound to the resulting match--and then compute a property that *will* be exposed. For example, the `_it` property in the following grammar will not be exposed, and is used to compute the `test` property.
 
 ```typescript
-const NodeTestGrammar = {
+const NodeTestGrammar = microgrammar({
     _it: firstOf("*", NodeName),
     test: ctx => ctx._it === "*" ? AllNodeTest : new NamedNodeTest(ctx._it),
-};
+});
 ```
 
 ## Validation functions
@@ -21,7 +21,7 @@ A validation function is any function that returns `boolean` whose name begins w
 For example:
 
 ```typescript
-Microgrammar.fromDefinitions<ChangeControlledMethod>({
+microgrammar<ChangeControlledMethod>({
     annotations: new Rep1(AnyAnnotation),
     _check(ctx: any) {
         const found = ctx.annotations.filter(a => a.name === "ChangeControlled");

--- a/docs/objectDefs.md
+++ b/docs/objectDefs.md
@@ -6,7 +6,7 @@ In this style, microgrammars are defined in JavaScript objects, with the matcher
 For example:
 
 ```typescript
-const mg = Microgrammar.fromDefinitions<{name: string, age: number}>({
+const mg = microgrammar(<{name: string, age: number}>({
     name: /[a-zA-Z0-9]+/,
     _col: ":",
     age: Integer
@@ -32,14 +32,14 @@ Object definitions can be composed.
 The above example can be rewritten as follows:
 
 ```typescript
-const mg = Microgrammar.fromDefinitionsAs({
+const mg = simpleMicrogrammar({
     name: /[a-zA-Z0-9]+/,
     _col: ":",
     age: Integer
 });
 ```
 
-By using the `fromDefinitionsAs` static method to construct a `Microgrammar` instance you sacrifice control over the result type for convenience. Here we don't specify a result type, but it is inferred from the definitions. The inferred result type would look as follows:
+By using the `simpleMicogrammar` method to construct a microgrammar instance you sacrifice control over the result type for convenience. Here we don't specify a result type, but it is inferred from the definitions. The inferred result type would look as follows:
 
 ```typescript
 { name: any, _col: any, age: any }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -46,7 +46,7 @@ among other annotations, it's impossible to express that in the grammar itself. 
 annotation was present and veto the match if it wasn't.
 
 ```typescript
-Microgrammar.fromDefinitions<ChangeControlledMethod>({
+microgrammar<ChangeControlledMethod>({
     annotations: new Rep1(AnyAnnotation),
     _check(ctx: any) {
         const found = ctx.annotations.filter(a => a.name === "ChangeControlled");

--- a/docs/providedMatchers.md
+++ b/docs/providedMatchers.md
@@ -47,4 +47,4 @@ These matches have been tested with Java, but should be useful for any C family 
 | blockContaining | `index` | Java block containing a match of the given matcher
 
 
-It is also easy to [define your own matchers](customMatchers.md).
+You can also [define your own matchers](customMatchers.md).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -13,5 +13,5 @@
 - [Handling circular references](circularity.md) via lazy matchers
 - Implementing [custom matchers](customMatchers.md)
 - Maintaining [state](state.md) while matching
-- [Troubleshooting](trouble.md) tips
+1. - [Troubleshooting](trouble.md) tips
 - [Performance](performance.md) tips

--- a/docs/stringDefs.md
+++ b/docs/stringDefs.md
@@ -1,13 +1,18 @@
 # String Definitions
 This is a higher level usage model in which a string resembling the desired input but with variable placeholders is used to define the grammar.
 
+To do this, specify the optional `phrase` property in the call to the `microgrammar` or `simpleMicrogrammar` function. Any term definitions should be passed in the `terms` property. 
+
+## Examples
+
 Variable placeholders follow TypeScript style for variable placheholders in interpolated strings, e.g. `static ${embeddedVariable} more static`.
 
 This style is ideally suited for simpler grammars. For example:
 
 ```typescript
-const ValuePredicateGrammar = Microgrammar.fromString<Predicate>(
-    "@${name}='${value}'");
+const ValuePredicateGrammar = microgrammar<Predicate>({
+    phrase: "@${name}='${value}'",
+});
 ```
 By default, this will skip over characters that don't match the string literals. For example, `name` will match anything up to but not including a `'`.
 
@@ -16,11 +21,38 @@ As with the object definitional style, whitespace will be ignored by default.
 This style can be combined with the definitional style through providing optional definitions for the named fields. For example, to constrain the match on a name in the above exampl, we can use a regular expression:
 
 ```typescript
-const ValuePredicateGrammar = Microgrammar.fromString<Predicate>(
-    "@${name}='${value}'", {
+const ValuePredicateGrammar = ```typescript
+const ValuePredicateGrammar = microgrammar<Predicate>({
+    phrase: "@${name}='${value}'",
+    terms: {
         name: /[a-z]+/
-    });
+});
 ```
 
 When troubleshooting a problem with string-defined microgrammars, adding explicit definitions is often helpful.
 
+## Typing: How this works
+
+The `microgrammar` and `simpleMicrogrammar` functions take a union type as follows.
+
+```typescript
+function microgrammar(definition: MicrogrammarDefinition<T> | TermsDefinition<T>)
+```
+The full type of `MicrogrammarDefinition` is as follows:
+
+```typescript
+export interface MicrogrammarDefinition<T> {
+
+    /**
+     * Phrase defining how the terms should appear, including
+     * literals, if specified.
+     * A phrase is of form "method ${name}(): ${returnType}".
+     */
+    phrase?: string;
+
+    /**
+     * Definitions of the productions in this grammar
+     */
+    terms?: TermsDefinition<T>;
+}
+```

--- a/docs/trouble.md
+++ b/docs/trouble.md
@@ -4,7 +4,7 @@ Often your first attempts at a microgrammar will not match.
 
 Suggested steps:
 
-- **Write unit tests**. Microgrammars are easily unit testable. Test productions in isolation, rather than as part of an application. TDD works very well when developing with microgrammars. Start with simpler cases of input, and gradually build in complexity and completeness.
+- **Write unit tests**. Microgrammars are easily unit testable. **Test productions in isolation**, rather than as part of an application. TDD works very well when developing with microgrammars. Start with simpler cases of input, and gradually build in complexity and completeness.
 - **Start small**. Complex productions are built from simple building blocks. Don't try to assemble a complex production in one go--break out the individual pieces and unit test each of them. This also fosters reuse.
 - **Refer to any existing formal grammars**. While microgrammars are intentionally incomplete when compared to BNF-style grammars, such grammars are often a valuable reference. You can find them in the definitions of languages such as Java. ANTLR grammars can also be a useful resource. Don't try to copy the full grammar, but do use it to understand the constructs.
 - **Test regular expression terms in isolation.** While using microgrammars can help avoid having to write excessively complex regular expressions, you *will* certainly still use regular expressions, and when in doubt write unit tests for them.

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,8 @@ export * from "./lib/Microgrammar";
 
 export * from "./lib/Grammar";
 
+export * from "./lib/microgrammarConstruction";
+
 export * from "./lib/Ops";
 
 export { isPatternMatch } from "./lib/PatternMatch";

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,8 @@ export { isSuccessfulMatch } from "./lib/MatchPrefixResult";
 
 export * from "./lib/Microgrammar";
 
+export * from "./lib/Grammar";
+
 export * from "./lib/Ops";
 
 export { isPatternMatch } from "./lib/PatternMatch";

--- a/lib/Grammar.ts
+++ b/lib/Grammar.ts
@@ -39,6 +39,17 @@ export interface Grammar<T> extends Term {
     matchIterator(input: string | InputStream, parseContext?: object, l?: Listeners): Iterable<PatternMatch>;
 
     /**
+     * Convenience method to find matches. Note that this will parse the entire input in one pass.
+     * Use matchIterator if you are likely to try to stop part-way through, or want to be
+     * kinder to the event loop.
+     * @param input
+     * @param parseContext context for the whole parsing operation
+     * @param l listeners observing input characters as they are read
+     * @return {PatternMatch[]}
+     */
+    findMatches(input: string | InputStream, parseContext?: object, l?: Listeners): Array<T & PatternMatch>;
+
+    /**
      * Convenient method to find the first match, or null if not found.
      * Stops searching after the first match.
      * @param input
@@ -79,15 +90,14 @@ export interface MicrogrammarDefinition<T> {
 }
 
 /**
- * Create a microgrammar with typed properties according
+ * Create a microgrammar return matches with properties according
  * to the given interface.
- * If the definitions aren't nested, infer string type
- * @param definition
+ * @param definition full definition or terms definition
  * @return {Grammar<T>}
  */
-export function microgrammar<T>(definition: MicrogrammarDefinition<T>): Grammar<T> {
+export function microgrammar<T>(definition: MicrogrammarDefinition<T> | TermsDefinition<T>): Grammar<T> {
     if (!definition.phrase && !definition.terms) {
-        throw new Error("At leat one of string and terms must be supplied to construct a microgrammar");
+        return Microgrammar.fromDefinitions(definition as any);
     }
     if (!!definition.phrase) {
         return Microgrammar.fromString(definition.phrase, definition.terms);
@@ -96,11 +106,11 @@ export function microgrammar<T>(definition: MicrogrammarDefinition<T>): Grammar<
 }
 
 /**
- * Create a microgrammar with inferred interface taking properties of type "any" from definitions.
- * Use fromDefinitions for stronger typing.
- * If the definitions aren't nested, infer string type
+ * Create a microgrammar with return matches implementing an inferred interface
+ * taking properties of type "any" from definitions.
+ * Use microgrammar for stronger typing.
  * @return {Grammar<T>}
  */
-export function simpleMicrogrammar<T>(definition: MicrogrammarDefinition<T>): Grammar<AnyKeysOf<T>> {
+export function simpleMicrogrammar<T>(definition: MicrogrammarDefinition<T> | TermsDefinition<T>): Grammar<AnyKeysOf<T>> {
     return microgrammar(definition);
 }

--- a/lib/Grammar.ts
+++ b/lib/Grammar.ts
@@ -36,7 +36,7 @@ export interface Grammar<T> extends Term {
      * @param {Listeners} l
      * @return {Iterable<PatternMatch>}
      */
-    matchIterator(input: string | InputStream, parseContext?, l?: Listeners): Iterable<PatternMatch>;
+    matchIterator(input: string | InputStream, parseContext?: object, l?: Listeners): Iterable<PatternMatch>;
 
     /**
      * Convenient method to find the first match, or null if not found.
@@ -56,7 +56,7 @@ export interface Grammar<T> extends Term {
      * @param l listeners observing input characters as they are read
      * @return {PatternMatch&T}
      */
-    exactMatch(input: string | InputStream, parseContext?, l ?: Listeners): PatternMatch & T | DismatchReport;
+    exactMatch(input: string | InputStream, parseContext?: object, l ?: Listeners): PatternMatch & T | DismatchReport;
 
 }
 
@@ -66,9 +66,11 @@ export interface Grammar<T> extends Term {
 export interface MicrogrammarDefinition<T> {
 
     /**
-     * Expression is of form "method ${name}(): ${returnType}".
+     * Phrase defining how the terms should appear, including
+     * literals, if specified.
+     * A phrase is of form "method ${name}(): ${returnType}".
      */
-    expression?: string;
+    phrase?: string;
 
     /**
      * Definitions of the productions in this grammar
@@ -84,11 +86,11 @@ export interface MicrogrammarDefinition<T> {
  * @return {Grammar<T>}
  */
 export function microgrammar<T>(definition: MicrogrammarDefinition<T>): Grammar<T> {
-    if (!definition.expression && !definition.terms) {
+    if (!definition.phrase && !definition.terms) {
         throw new Error("At leat one of string and terms must be supplied to construct a microgrammar");
     }
-    if (!!definition.expression) {
-        return Microgrammar.fromString(definition.expression, definition.terms);
+    if (!!definition.phrase) {
+        return Microgrammar.fromString(definition.phrase, definition.terms);
     }
     return Microgrammar.fromDefinitions(definition.terms);
 }
@@ -99,7 +101,6 @@ export function microgrammar<T>(definition: MicrogrammarDefinition<T>): Grammar<
  * If the definitions aren't nested, infer string type
  * @return {Grammar<T>}
  */
-
 export function simpleMicrogrammar<T>(definition: MicrogrammarDefinition<T>): Grammar<AnyKeysOf<T>> {
     return microgrammar(definition);
 }

--- a/lib/Grammar.ts
+++ b/lib/Grammar.ts
@@ -1,18 +1,11 @@
 import { Listeners } from "./InputState";
 import { Term } from "./Matchers";
 import { TermDef } from "./matchers/Concat";
-import {
-    DismatchReport,
-    PatternMatch,
-} from "./PatternMatch";
+import { DismatchReport, PatternMatch } from "./PatternMatch";
 
 import { InputStream } from "./spi/InputStream";
 
-import {
-    SkipCapable,
-    WhiteSpaceHandler,
-} from "./Config";
-import { Microgrammar } from "./Microgrammar";
+import { SkipCapable, WhiteSpaceHandler } from "./Config";
 
 export type AllowableTermDef<PARAMS> = (TermDef | ((ctx: PARAMS & any) => any) | { [index: string]: any });
 
@@ -73,48 +66,4 @@ export interface Grammar<T> extends Term {
      */
     exactMatch(input: string | InputStream, parseContext?: object, l ?: Listeners): PatternMatch & T | DismatchReport;
 
-}
-
-/**
- * Object used to define a microgrammar
- */
-export interface MicrogrammarDefinition<T> {
-
-    /**
-     * Phrase defining how the terms should appear, including
-     * literals, if specified.
-     * A phrase is of form "method ${name}(): ${returnType}".
-     */
-    phrase?: string;
-
-    /**
-     * Definitions of the productions in this grammar
-     */
-    terms?: TermsDefinition<T>;
-}
-
-/**
- * Create a microgrammar return matches with properties according
- * to the given interface.
- * @param definition full definition, including a phrase string, or terms definition
- * @return {Grammar<T>}
- */
-export function microgrammar<T>(definition: MicrogrammarDefinition<T> | TermsDefinition<T>): Grammar<T> {
-    if (!definition.phrase && !definition.terms) {
-        return Microgrammar.fromDefinitions(definition as any);
-    }
-    if (!!definition.phrase) {
-        return Microgrammar.fromString(definition.phrase, definition.terms);
-    }
-    return Microgrammar.fromDefinitions(definition.terms);
-}
-
-/**
- * Create a microgrammar with return matches implementing an inferred interface
- * taking properties of type "any" from definitions.
- * Use microgrammar for stronger typing.
- * @return {Grammar<T>}
- */
-export function simpleMicrogrammar<T>(definition: MicrogrammarDefinition<T> | TermsDefinition<T>): Grammar<AnyKeysOf<T>> {
-    return microgrammar(definition);
 }

--- a/lib/Grammar.ts
+++ b/lib/Grammar.ts
@@ -1,11 +1,17 @@
 import { Listeners } from "./InputState";
 import { Term } from "./Matchers";
 import { TermDef } from "./matchers/Concat";
-import { DismatchReport, PatternMatch } from "./PatternMatch";
+import {
+    DismatchReport,
+    PatternMatch,
+} from "./PatternMatch";
 
 import { InputStream } from "./spi/InputStream";
 
-import { SkipCapable, WhiteSpaceHandler } from "./Config";
+import {
+    SkipCapable,
+    WhiteSpaceHandler,
+} from "./Config";
 
 export type AllowableTermDef<PARAMS> = (TermDef | ((ctx: PARAMS & any) => any) | { [index: string]: any });
 

--- a/lib/Grammar.ts
+++ b/lib/Grammar.ts
@@ -1,0 +1,99 @@
+import { Listeners } from "./InputState";
+import { Term } from "./Matchers";
+import { TermDef } from "./matchers/Concat";
+import { DismatchReport, PatternMatch } from "./PatternMatch";
+
+import { InputStream } from "./spi/InputStream";
+
+import { SkipCapable, WhiteSpaceHandler } from "./Config";
+import { Microgrammar } from "./Microgrammar";
+
+export type AllowableTermDef<PARAMS> = (TermDef | ((ctx: PARAMS & any) => any) | { [index: string]: any });
+
+export type TermsDefinition<PARAMS, K extends keyof PARAMS = keyof PARAMS> =
+    Record<K, AllowableTermDef<PARAMS>> & Partial<WhiteSpaceHandler> & Partial<SkipCapable>
+    & { [index: string]: any };
+
+export type AnyKeysOf<T, K extends keyof T = keyof T> = Record<K, any>;
+
+/**
+ * Central interface for microgrammar usage.
+ * Represents a microgrammar that we can use to match input
+ * in a string or stream.
+ */
+export interface Grammar<T> extends Term {
+
+    /**
+     * Generator for matching the given input.
+     * @param {string | InputStream} input
+     * @param {{}} parseContext
+     * @param {Listeners} l
+     * @return {Iterable<PatternMatch>}
+     */
+    matchIterator(input: string | InputStream, parseContext?, l?: Listeners): Iterable<PatternMatch>;
+
+    /**
+     * Convenient method to find the first match, or null if not found.
+     * Stops searching after the first match.
+     * @param input
+     * @param l listeners observing input characters as they are read
+     * @returns {PatternMatch[]}
+     */
+    firstMatch(input: string | InputStream, l?: Listeners): PatternMatch & T | null;
+
+    /**
+     * Return a match if it explains the whole of the input.
+     * This style of usage is more like a traditional parser,
+     * building an AST for a whole file.
+     * @param input
+     * @param parseContext context for the whole parsing operation
+     * @param l listeners observing input characters as they are read
+     * @return {PatternMatch&T}
+     */
+    exactMatch(input: string | InputStream, parseContext?, l ?: Listeners): PatternMatch & T | DismatchReport;
+
+}
+
+/**
+ * Object used to define a microgrammar
+ */
+export interface MicrogrammarDefinition<T> {
+
+    /**
+     * Expression is of form "method ${name}(): ${returnType}".
+     */
+    expression?: string;
+
+    /**
+     * Definitions of the productions in this grammar
+     */
+    terms?: TermsDefinition<T>;
+}
+
+/**
+ * Create a microgrammar with typed properties according
+ * to the given interface.
+ * If the definitions aren't nested, infer string type
+ * @param definition
+ * @return {Grammar<T>}
+ */
+export function microgrammar<T>(definition: MicrogrammarDefinition<T>): Grammar<T> {
+    if (!definition.expression && !definition.terms) {
+        throw new Error("At leat one of string and terms must be supplied to construct a microgrammar");
+    }
+    if (!!definition.expression) {
+        return Microgrammar.fromString(definition.expression, definition.terms);
+    }
+    return Microgrammar.fromDefinitions(definition.terms);
+}
+
+/**
+ * Create a microgrammar with inferred interface taking properties of type "any" from definitions.
+ * Use fromDefinitions for stronger typing.
+ * If the definitions aren't nested, infer string type
+ * @return {Grammar<T>}
+ */
+
+export function simpleMicrogrammar<T>(definition: MicrogrammarDefinition<T>): Grammar<AnyKeysOf<T>> {
+    return microgrammar(definition);
+}

--- a/lib/Grammar.ts
+++ b/lib/Grammar.ts
@@ -1,11 +1,17 @@
 import { Listeners } from "./InputState";
 import { Term } from "./Matchers";
 import { TermDef } from "./matchers/Concat";
-import { DismatchReport, PatternMatch } from "./PatternMatch";
+import {
+    DismatchReport,
+    PatternMatch,
+} from "./PatternMatch";
 
 import { InputStream } from "./spi/InputStream";
 
-import { SkipCapable, WhiteSpaceHandler } from "./Config";
+import {
+    SkipCapable,
+    WhiteSpaceHandler,
+} from "./Config";
 import { Microgrammar } from "./Microgrammar";
 
 export type AllowableTermDef<PARAMS> = (TermDef | ((ctx: PARAMS & any) => any) | { [index: string]: any });

--- a/lib/Grammar.ts
+++ b/lib/Grammar.ts
@@ -20,6 +20,10 @@ export type TermsDefinition<PARAMS, K extends keyof PARAMS = keyof PARAMS> =
     Record<K, AllowableTermDef<PARAMS>> & Partial<WhiteSpaceHandler> & Partial<SkipCapable>
     & { [index: string]: any };
 
+/**
+ * Record with values of any type for every key K found in T.
+ * Convenient inferred return type for microgrammar.
+ */
 export type AnyKeysOf<T, K extends keyof T = keyof T> = Record<K, any>;
 
 /**
@@ -92,7 +96,7 @@ export interface MicrogrammarDefinition<T> {
 /**
  * Create a microgrammar return matches with properties according
  * to the given interface.
- * @param definition full definition or terms definition
+ * @param definition full definition, including a phrase string, or terms definition
  * @return {Grammar<T>}
  */
 export function microgrammar<T>(definition: MicrogrammarDefinition<T> | TermsDefinition<T>): Grammar<T> {

--- a/lib/Microgrammar.ts
+++ b/lib/Microgrammar.ts
@@ -1,17 +1,34 @@
-import { InputState, Listeners } from "./InputState";
+import {
+    InputState,
+    Listeners,
+} from "./InputState";
 import { MatchingLogic } from "./Matchers";
-import { Concat, Concatenation, toMatchingLogic } from "./matchers/Concat";
+import {
+    Concat,
+    Concatenation,
+    toMatchingLogic,
+} from "./matchers/Concat";
 import { isSuccessfulMatch } from "./MatchPrefixResult";
-import { DismatchReport, PatternMatch } from "./PatternMatch";
+import {
+    DismatchReport,
+    PatternMatch,
+} from "./PatternMatch";
 
 import { FromStringOptions } from "./FromStringOptions";
-import { AnyKeysOf, Grammar, TermsDefinition } from "./Grammar";
+import {
+    AnyKeysOf,
+    Grammar,
+    TermsDefinition,
+} from "./Grammar";
 import { ChangeSet } from "./internal/ChangeSet";
 import { DefaultInputState } from "./internal/DefaultInputState";
 import { exactMatch } from "./internal/ExactMatch";
 import { InputStateManager } from "./internal/InputStateManager";
 import { MicrogrammarSpecParser } from "./internal/MicrogrammarSpecParser";
-import { MatchUpdater, MicrogrammarUpdates } from "./internal/MicrogrammarUpdates";
+import {
+    MatchUpdater,
+    MicrogrammarUpdates,
+} from "./internal/MicrogrammarUpdates";
 import { readyToMatch } from "./internal/Whitespace";
 import { InputStream } from "./spi/InputStream";
 import { StringInputStream } from "./spi/StringInputStream";

--- a/lib/Microgrammar.ts
+++ b/lib/Microgrammar.ts
@@ -1,41 +1,20 @@
-import {
-    InputState,
-    Listeners,
-} from "./InputState";
-import {
-    MatchingLogic,
-    Term,
-} from "./Matchers";
-import {
-    Concat,
-    Concatenation,
-    TermDef,
-    toMatchingLogic,
-} from "./matchers/Concat";
+import { InputState, Listeners } from "./InputState";
+import { MatchingLogic } from "./Matchers";
+import { Concat, Concatenation, toMatchingLogic } from "./matchers/Concat";
 import { isSuccessfulMatch } from "./MatchPrefixResult";
-import {
-    DismatchReport,
-    PatternMatch,
-} from "./PatternMatch";
+import { DismatchReport, PatternMatch } from "./PatternMatch";
 
-import { InputStream } from "./spi/InputStream";
-import { StringInputStream } from "./spi/StringInputStream";
-
-import {
-    SkipCapable,
-    WhiteSpaceHandler,
-} from "./Config";
 import { FromStringOptions } from "./FromStringOptions";
+import { AnyKeysOf, Grammar, TermsDefinition } from "./Grammar";
 import { ChangeSet } from "./internal/ChangeSet";
 import { DefaultInputState } from "./internal/DefaultInputState";
 import { exactMatch } from "./internal/ExactMatch";
 import { InputStateManager } from "./internal/InputStateManager";
 import { MicrogrammarSpecParser } from "./internal/MicrogrammarSpecParser";
-import {
-    MatchUpdater,
-    MicrogrammarUpdates,
-} from "./internal/MicrogrammarUpdates";
+import { MatchUpdater, MicrogrammarUpdates } from "./internal/MicrogrammarUpdates";
 import { readyToMatch } from "./internal/Whitespace";
+import { InputStream } from "./spi/InputStream";
+import { StringInputStream } from "./spi/StringInputStream";
 
 /**
  * Holds a set of updatable matches
@@ -57,14 +36,6 @@ export class Updatable<T> {
     }
 }
 
-export type AllowableTermDef<PARAMS> = (TermDef | ((ctx: PARAMS & any) => any) | { [index: string]: any });
-
-export type TermsDefinition<PARAMS, K extends keyof PARAMS = keyof PARAMS> =
-    Record<K, AllowableTermDef<PARAMS>> & Partial<WhiteSpaceHandler> & Partial<SkipCapable>
-    & { [index: string]: any };
-
-export type AnyKeysOf<T, K extends keyof T = keyof T> = Record<K, any>;
-
 /**
  * Central class for microgrammar usage.
  * Represents a microgrammar that we can use to match input
@@ -72,7 +43,7 @@ export type AnyKeysOf<T, K extends keyof T = keyof T> = Record<K, any>;
  * Modifications are tracked and we can get an updated string
  * afterwards.
  */
-export class Microgrammar<T> implements Term {
+export class Microgrammar<T> implements Grammar<T> {
 
     /**
      * Make this match transparently updatable using property mutation

--- a/lib/microgrammarConstruction.ts
+++ b/lib/microgrammarConstruction.ts
@@ -1,0 +1,46 @@
+import { AnyKeysOf, Grammar, TermsDefinition } from "./Grammar";
+import { Microgrammar } from "./Microgrammar";
+
+/**
+ * Object used to define a microgrammar
+ */
+export interface MicrogrammarDefinition<T> {
+
+    /**
+     * Phrase defining how the terms should appear, including
+     * literals, if specified.
+     * A phrase is of form "method ${name}(): ${returnType}".
+     */
+    phrase?: string;
+
+    /**
+     * Definitions of the productions in this grammar
+     */
+    terms?: TermsDefinition<T>;
+}
+
+/**
+ * Create a microgrammar return matches with properties according
+ * to the given interface.
+ * @param definition full definition, including a phrase string, or terms definition
+ * @return {Grammar<T>}
+ */
+export function microgrammar<T>(definition: MicrogrammarDefinition<T> | TermsDefinition<T>): Grammar<T> {
+    if (!definition.phrase && !definition.terms) {
+        return Microgrammar.fromDefinitions(definition as any);
+    }
+    if (!!definition.phrase) {
+        return Microgrammar.fromString(definition.phrase, definition.terms);
+    }
+    return Microgrammar.fromDefinitions(definition.terms);
+}
+
+/**
+ * Create a microgrammar with return matches implementing an inferred interface
+ * taking properties of type "any" from definitions.
+ * Use microgrammar for stronger typing.
+ * @return {Grammar<T>}
+ */
+export function simpleMicrogrammar<T>(definition: MicrogrammarDefinition<T> | TermsDefinition<T>): Grammar<AnyKeysOf<T>> {
+    return microgrammar(definition);
+}

--- a/lib/microgrammarConstruction.ts
+++ b/lib/microgrammarConstruction.ts
@@ -1,4 +1,8 @@
-import { AnyKeysOf, Grammar, TermsDefinition } from "./Grammar";
+import {
+    AnyKeysOf,
+    Grammar,
+    TermsDefinition,
+} from "./Grammar";
 import { Microgrammar } from "./Microgrammar";
 
 /**

--- a/test/MavenGrammars.ts
+++ b/test/MavenGrammars.ts
@@ -1,10 +1,6 @@
 import { Concat } from "../lib/matchers/Concat";
 import { Microgrammar } from "../lib/Microgrammar";
-import {
-    Opt,
-    when,
-} from "../lib/Ops";
-import { Rep, Rep1 } from "../lib/Rep";
+import { Opt } from "../lib/Ops";
 
 export interface VersionedArtifact {
     group: string;
@@ -76,29 +72,6 @@ export const ALL_PLUGIN_GRAMMAR =
         version: ctx => ctx._version ? ctx._version.version : undefined,
     });
 
-const property = {
-    _gt: "<",
-    name: LEGAL_VALUE,
-    _close: ">",
-    value: /[^<]+/,
-    _gt2: "</",
-    _closing: LEGAL_VALUE,
-    _done: ">",
-};
-
-export const PROPERTIES_GRAMMAR = Microgrammar.fromDefinitions<PropertiesBlock>({
-    _po: "<properties>",
-    properties: new Rep(property),
-    // _pe: "</properties>"
-});
-
-/**
- * Interface for returned property
- */
-export interface PropertiesBlock {
-    properties: Array<{ name: string, value: string }>;
-}
-
 export const XML_TAG_WITH_SIMPLE_VALUE = Concat.of({
     _l: "<",
     name: LEGAL_VALUE,
@@ -114,11 +87,6 @@ export interface XmlTag {
     name: string;
     value: string;
 }
-
-export const GAV_CONCAT = when(Concat.of({
-    tags: new Rep1(XML_TAG_WITH_SIMPLE_VALUE),
-}), pm => (pm as any).tags.filter(t => t.name === "groupId").length > 0 &&
-    (pm as any).tags.filter(t => t.name === "artifactId").length > 0);
 
 export class GAV {
 

--- a/test/Microgrammar.test.ts
+++ b/test/Microgrammar.test.ts
@@ -28,6 +28,7 @@ import {
     PLUGIN_GRAMMAR,
     VersionedArtifact,
 } from "./MavenGrammars";
+import { Integer } from "../lib";
 
 /* tslint:disable:max-file-line-count */
 
@@ -59,7 +60,7 @@ describe("Microgrammar", () => {
             }
         });
 
-        it("should infer from definitions", () => {
+        it("should infer from definitions and string", () => {
             const mg = microgrammar<{ forename: string, surname: string }>(
                 { phrase: "${forename} ${surname}", terms: { forename: "forename", surname: /.*/ } });
             // This will never match, but is just to test for compilation
@@ -68,6 +69,23 @@ describe("Microgrammar", () => {
                 const s = match.forename + match.surname;
                 assert(!!s);
             }
+        });
+
+        it("should support composition", () => {
+            interface Person { forename: string; surname: string; }
+            const person = microgrammar<Person>(
+                { phrase: "${forename} ${surname}", terms: { forename: /[a-zA-Z]+/, surname: /[a-zA-Z]+/ } });
+            const employee = microgrammar<{person: Person, id: number}>({
+                person,
+                id: Integer,
+            });
+            const pmatch = person.firstMatch("Warren Buffet 3003");
+            assert(!!pmatch);
+            assert.strictEqual(pmatch.surname, "Buffet");
+            const ematch = employee.firstMatch("Warren Buffet 3003");
+            assert(!!ematch);
+            assert.strictEqual(ematch.person.surname, "Buffet");
+            assert.strictEqual(ematch.id, 3003);
         });
 
     });

--- a/test/Microgrammar.test.ts
+++ b/test/Microgrammar.test.ts
@@ -114,7 +114,7 @@ describe("Microgrammar", () => {
 
     it("XML element", () => {
         const content = "<foo>";
-        const mg = Microgrammar.fromDefinitions({
+        const mg = microgrammar({
             lx: "<",
             name: /[a-zA-Z0-9]+/,
             rx: ">",
@@ -194,7 +194,7 @@ describe("Microgrammar", () => {
 
     it("2 elements: whitespace insensitive", () => {
         const content = "<first> notxml";
-        const mg = Microgrammar.fromDefinitions({
+        const mg = microgrammar({
             _lx: "<",
             namex: /[a-zA-Z0-9]+/,
             _rx: ">",
@@ -315,13 +315,17 @@ describe("Microgrammar", () => {
             name: /[a-zA-Z0-9]+/,
             rx: ">",
         };
-        const mg = Microgrammar.fromDefinitions({
+        const mg = microgrammar({
             first: element,
             second: new Opt(element),
         });
-        const result = mg.findMatches(content);
+        const it = mg.matchIterator(content);
+        const result = [];
+        for (const m of it) {
+            result.push(m);
+        }
         expect(result.length).to.equal(1);
-        const r0 = result[0] as any;
+        const r0 = result[0];
         assert(isPatternMatch(r0));
         assert(r0.$matched === content);
         assert(r0.first);

--- a/test/Microgrammar.test.ts
+++ b/test/Microgrammar.test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import * as assert from "power-assert";
 import { fail } from "power-assert";
 import { WhiteSpaceSensitive } from "../lib/Config";
+import { microgrammar, simpleMicrogrammar } from "../lib/Grammar";
 import { MatchingLogic } from "../lib/Matchers";
 import {
     MatchingMachine,
@@ -33,6 +34,31 @@ describe("Microgrammar", () => {
 
         it("should infer from definitions", () => {
             const mg = Microgrammar.fromDefinitionsAs({ forename: "forename", surname: /.*/ });
+            // This will never match, but is just to test for compilation
+            const match = mg.firstMatch("");
+            if (match) {
+                const s = match.forename + match.surname;
+                assert(!!s);
+            }
+        });
+
+    });
+
+    describe("interface construction", () => {
+
+        it("should infer from definitions", () => {
+            const mg = simpleMicrogrammar({ terms: { forename: "forename", surname: /.*/ } });
+            // This will never match, but is just to test for compilation
+            const match = mg.firstMatch("");
+            if (match) {
+                const s = match.forename + match.surname;
+                assert(!!s);
+            }
+        });
+
+        it("should infer from definitions", () => {
+            const mg = microgrammar<{ forename: string, surname: string }>(
+                { expression: "${forename} ${surname}", terms: { forename: "forename", surname: /.*/ } });
             // This will never match, but is just to test for compilation
             const match = mg.firstMatch("");
             if (match) {

--- a/test/Microgrammar.test.ts
+++ b/test/Microgrammar.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import * as assert from "power-assert";
 import { fail } from "power-assert";
+import { Integer } from "../lib";
 import { WhiteSpaceSensitive } from "../lib/Config";
 import {
     microgrammar,
@@ -28,7 +29,6 @@ import {
     PLUGIN_GRAMMAR,
     VersionedArtifact,
 } from "./MavenGrammars";
-import { Integer } from "../lib";
 
 /* tslint:disable:max-file-line-count */
 

--- a/test/Microgrammar.test.ts
+++ b/test/Microgrammar.test.ts
@@ -61,7 +61,7 @@ describe("Microgrammar", () => {
 
         it("should infer from definitions", () => {
             const mg = microgrammar<{ forename: string, surname: string }>(
-                { expression: "${forename} ${surname}", terms: { forename: "forename", surname: /.*/ } });
+                { phrase: "${forename} ${surname}", terms: { forename: "forename", surname: /.*/ } });
             // This will never match, but is just to test for compilation
             const match = mg.firstMatch("");
             if (match) {

--- a/test/Microgrammar.test.ts
+++ b/test/Microgrammar.test.ts
@@ -3,15 +3,15 @@ import * as assert from "power-assert";
 import { fail } from "power-assert";
 import { Integer } from "../lib";
 import { WhiteSpaceSensitive } from "../lib/Config";
-import {
-    microgrammar,
-    simpleMicrogrammar,
-} from "../lib/Grammar";
 import { MatchingLogic } from "../lib/Matchers";
 import {
     MatchingMachine,
     Microgrammar,
 } from "../lib/Microgrammar";
+import {
+    microgrammar,
+    simpleMicrogrammar,
+} from "../lib/microgrammarConstruction";
 import {
     Alt,
     Opt,

--- a/test/Microgrammar.test.ts
+++ b/test/Microgrammar.test.ts
@@ -2,7 +2,10 @@ import { expect } from "chai";
 import * as assert from "power-assert";
 import { fail } from "power-assert";
 import { WhiteSpaceSensitive } from "../lib/Config";
-import { microgrammar, simpleMicrogrammar } from "../lib/Grammar";
+import {
+    microgrammar,
+    simpleMicrogrammar,
+} from "../lib/Grammar";
 import { MatchingLogic } from "../lib/Matchers";
 import {
     MatchingMachine,


### PR DESCRIPTION
Depending on a concrete class such as `Microgrammar` can cause node module issues. This PR introduces a new `microgrammar` function and `Grammar` interface that allows construction of microgrammars without importing a class.

For example:

```typescript
 const mg = microgrammar({
       first: element,
       second: new Opt(element),
});
```
is equivalent to

```typescript
 const mg = Microgrammar.fromDefinitions({
       first: element,
       second: new Opt(element),
});
```

While:
```typescript
 const mg = microgrammar({
       phrase: "${first} and other stuff and then ${second}",
       terms: { first: element,
       second: new Opt(element),
     }
});
```
is equivalent to

```typescript
 const mg = Microgrammar.fromString("${first} and other stuff and then ${second}", {
       first: element,
       second: new Opt(element),
});
```

The new `Grammar` interface is compatible with `Microgrammar` but omits some methods. This is to reduce the API load and encourage good usage. Updatable microgrammars are not supported in the new model. Consuming microgrammars via path expressions means this capability isn't needed; when it is needed in this library, use the old `Microgrammar` class.

